### PR TITLE
Fix a small bug with the automatic construction of the `tarball_name`

### DIFF
--- a/images/buildkite_agent_linux.jl
+++ b/images/buildkite_agent_linux.jl
@@ -4,7 +4,7 @@
 
 include(joinpath(dirname(@__DIR__), "rootfs_utils.jl"))
 arch, = parse_args(ARGS)
-image = "$(basename(@__FILE__)).$(arch)"
+image = "$(splitext(basename(@__FILE__))[1]).$(arch)"
 
 # Build debian-based image with the following extra packages:
 packages = [

--- a/images/package_linux.jl
+++ b/images/package_linux.jl
@@ -3,7 +3,7 @@
 
 include(joinpath(dirname(@__DIR__), "rootfs_utils.jl"))
 arch, = parse_args(ARGS)
-image = "$(basename(@__FILE__)).$(arch)"
+image = "$(splitext(basename(@__FILE__))[1]).$(arch)"
 
 # Build debian-based image with the following extra packages:
 packages = [

--- a/images/package_musl.jl
+++ b/images/package_musl.jl
@@ -3,7 +3,7 @@
 
 include(joinpath(dirname(@__DIR__), "rootfs_utils.jl"))
 arch, = parse_args(ARGS)
-image = "$(basename(@__FILE__)).$(arch)"
+image = "$(splitext(basename(@__FILE__))[1]).$(arch)"
 
 # Build alpine-based image with the following extra packages:
 packages = [


### PR DESCRIPTION
I was accidentally including the `.jl` file extension in the `tarball_name`.

Before this PR, an example `tarball_name` is:
- `buildkite_agent_linux.jl.x86_64.tar.gz`

After this PR, an example `tarball_name` is:
- `buildkite_agent_linux.x86_64.tar.gz`
