### PR TITLE
Add the Sandbox.jl package as a dependency to the environment

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -33,6 +33,10 @@ git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.3.0"
 
+[[LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
@@ -94,6 +98,12 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
+[[Sandbox]]
+deps = ["LazyArtifacts", "Libdl", "Preferences", "Random", "SHA", "Scratch", "TOML", "Tar", "UserNSSandbox_jll"]
+git-tree-sha1 = "36cd9e7d56858dabcd6fd65a9414901443ceaea9"
+uuid = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
+version = "1.0.1"
+
 [[Scratch]]
 deps = ["Dates"]
 git-tree-sha1 = "0b4b7f1393cff97c33891da2a0bf69c6ed241fda"
@@ -125,6 +135,12 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[UserNSSandbox_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f89214f9bc411b306f160d45a4fdb541922d1935"
+uuid = "b88861f7-1d72-59dd-91e7-a8cc876a4984"
+version = "2021.4.22+0"
 
 [[Zlib_jll]]
 deps = ["Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,7 @@
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Sandbox = "9307e30f-c43e-9ca7-d17c-c2dc59df670d"
 Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 ghr_jll = "07c12ed4-43bc-5495-8a2a-d5838ef8d533"
 


### PR DESCRIPTION
The `test_rootfs.jl` script uses the Sandbox.jl package, so we might as well add it as a dependency to the environment.