### PR TITLE
Back for a limited time only: the `llvm_passes` image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
 
           # The `package_linux` images is `alpine`-based
           - 'package_musl.x86_64'
+          
+          # The `llvm_passes` image is a short-term solution for the `analyzegc` builder
+          - 'llvm_passes.x86_64'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/images/llvm_passes.jl
+++ b/images/llvm_passes.jl
@@ -1,0 +1,26 @@
+## This rootfs includes enough of a host toolchain to build the LLVM passes (such as `analyzegc`).
+
+include(joinpath(dirname(@__DIR__), "rootfs_utils.jl"))
+arch, = parse_args(ARGS)
+image = "$(splitext(basename(@__FILE__))[1]).$(arch)"
+
+# Build debian-based image with the following extra packages:
+packages = [
+    "build-essential",
+    "cmake",
+    "curl",
+    "gfortran",
+    "git",
+    "less",
+    "libatomic1",
+    "m4",
+    "perl",
+    "pkg-config",
+    "python",
+    "python3",
+    "wget",
+]
+tarball_path = debootstrap(arch, image; packages)
+
+# Upload it
+upload_rootfs_image_github_actions(tarball_path)


### PR DESCRIPTION
In the long term, we probably will want to get everything working with one of the `package` images, e.g. `package_linux`.

But in the short term, it will be easiest to use the `llvm_passes.x86_64` image for the `analyzegc` and `asan` builders.