### PR TITLE
Always print at least the `basename` of the `tarball_path`, even if we aren't actually creating the tarball file

### DIFF
--- a/rootfs_utils.jl
+++ b/rootfs_utils.jl
@@ -117,7 +117,7 @@ function create_rootfs(f::Function, name::String; force::Bool=false)
     # Archive it into a `.tar.gz` file (but only if this is not a pull request build).
     if is_github_actions_pr()
         info_msg = "Skipping tarball creation because the build is a `pull_request` build"
-        @info info_msg artifact_hash
+        @info info_msg basename(tarball_path) artifact_hash
         return nothing
     end
     @info "Archiving" tarball_path artifact_hash


### PR DESCRIPTION
That way, we can see what the filename of the tarball file _would have been_, even in PR builds.