### PR TITLE
debootstrap: Use Debian 8 `jessie` (instead of Debian 10 `buster`)

### DIFF
--- a/rootfs_utils.jl
+++ b/rootfs_utils.jl
@@ -179,7 +179,7 @@ function qemu_installed(image_arch::String)
 end
 
 function debootstrap(f::Function, arch::String, name::String;
-                     release::String="buster",
+                     release::String="jessie",
                      variant::String="minbase",
                      packages::Vector{String}=String[],
                      force::Bool=false)


### PR DESCRIPTION
If I understand correctly:
- Debian 8 `jessie` ships with glibc 2.19
- Debian 10 `buster` ships with glibc 2.28

I think we want to test that we can build Julia against an older glibc, right?

If so, then this PR uses `jessie` instead of `buster`, so that we can build Julia against glibc 2.19.