### PR TITLE
When building Debian-based rootfs images, at the end of the build, print the version of glibc to the log

### DIFF
--- a/images/package_linux.jl
+++ b/images/package_linux.jl
@@ -41,7 +41,9 @@ tarball_path = debootstrap(arch, image; packages) do rootfs
         ln -sf "\${tool}-9" "/usr/bin/\${tool}"
     done
     """
+    chroot(rootfs, "bash", "-c", "ldd --version"; uid=0, gid=0)
     chroot(rootfs, "bash", "-c", gcc_install_cmd; uid=0, gid=0)
+    chroot(rootfs, "bash", "-c", "ldd --version"; uid=0, gid=0)
 end
 
 # Upload it

--- a/rootfs_utils.jl
+++ b/rootfs_utils.jl
@@ -234,6 +234,9 @@ function debootstrap(f::Function, arch::String, name::String;
             println(io, "en_US.UTF-8 UTF-8")
         end
         chroot(rootfs, "locale-gen")
+
+        # Print the version of glibc
+        chroot(rootfs, "bash", "-c", "ldd --version"; uid=0, gid=0)
     end
 end
 # If no user callback is provided, default to doing nothing


### PR DESCRIPTION
This will make it easier to debug issues related to glibc version mismatches.