### PR TITLE
For the `package_linux` image, use Debian `stretch` (instead of Debian `buster`)

### DIFF
--- a/images/package_linux.jl
+++ b/images/package_linux.jl
@@ -26,7 +26,7 @@ packages = [
     "wget",
     "vim",
 ]
-tarball_path = debootstrap(arch, image; packages) do rootfs
+tarball_path = debootstrap(arch, image; packages, release = "stretch") do rootfs
     # Install GCC 9, specifically
     @info("Installing gcc-9")
     gcc_install_cmd = """


### PR DESCRIPTION
For `package_linux`, use Debian `stretch`.

For `tester_linux`, use Debian `buster`.