### PR TITLE
Install a newer version of glibc in the `tester_linux` images

### DIFF
--- a/images/tester_linux.jl
+++ b/images/tester_linux.jl
@@ -12,7 +12,9 @@ packages = [
     "vim",
 ]
 tarball_path = debootstrap(arch, image; packages) do rootfs
-    # Install GCC 9, specifically
+    # Install a newer version of glibc.
+    # This is just a short-term workaround.
+    # Once we have fixed issue #44, we should remove this workaround.
     @info("Installing a newer version of glibc")
     glibc_install_cmd = """
     echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \\

--- a/images/tester_linux.jl
+++ b/images/tester_linux.jl
@@ -11,7 +11,18 @@ packages = [
     "gdb",
     "vim",
 ]
-tarball_path = debootstrap(arch, image; packages)
+tarball_path = debootstrap(arch, image; packages) do rootfs
+    # Install GCC 9, specifically
+    @info("Installing a newer version of glibc")
+    glibc_install_cmd = """
+    echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \\
+    apt-get update && \\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \\
+        libc6 libc-bin
+    """
+    chroot(rootfs, "bash", "-c", glibc_install_cmd; uid=0, gid=0)
+    chroot(rootfs, "bash", "-c", "ldd --version"; uid=0, gid=0)
+end
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)


### PR DESCRIPTION
This is just a short-term solution so that we can run our `julia` binaries inside the `tester_linux64` images.

The best long-term solution will be #44.