### PR TITLE
Add the `package_centos6` and `tester_centos6` rootfs images (only for the `x86_64` architecture)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,11 @@ jobs:
           - 'package_linux.powerpc64le'
           - 'package_linux.x86_64'
 
+          # The `package_centos6` images are based on CentOS 6.
+          # The purpose of these images is to build Julia binaries for
+          # use on legacy systems with old versions of glibc (e.g. 2.12)
+          - 'package_centos6.x86_64'
+
           # The `package_musl` image is `alpine`-based.
           - 'package_musl.x86_64'
 
@@ -41,6 +46,10 @@ jobs:
           - 'tester_linux.i686'
           - 'tester_linux.powerpc64le'
           - 'tester_linux.x86_64'
+
+          # The `tester_centos6` images are based on CentOS 6.
+          # They do not include the compiler toolchain.
+          - 'tester_centos6.x86_64'
 
           # The `tester_musl` image is `alpine`-based.
           # It does not include the compiler toolchain.
@@ -54,8 +63,12 @@ jobs:
         with:
           version: '1.6'
           arch: x64
+      - run: sudo touch /etc/apt/sources.list.d/additional_debian.list
+      - run: echo 'deb [trusted=yes] http://deb.debian.org/debian buster main' | sudo tee -a /etc/apt/sources.list.d/additional_debian.list
+      - run: echo 'deb [trusted=yes] http://security.debian.org/debian-security buster/updates main' | sudo tee -a /etc/apt/sources.list.d/additional_debian.list
+      - run: echo 'deb [trusted=yes] http://deb.debian.org/debian buster-updates main' | sudo tee -a /etc/apt/sources.list.d/additional_debian.list
       - run: sudo apt-get update
-      - run: sudo apt-get -y install binfmt-support debootstrap qemu-user-static
+      - run: sudo apt-get -y install binfmt-support debootstrap qemu-user-static yum
       - run: update-binfmts --display
       - run: julia --color=yes --project=. -e 'using Pkg; Pkg.instantiate()'
       - run: julia --color=yes --project=. -e 'using Pkg; Pkg.precompile()'

--- a/images/package_centos6.jl
+++ b/images/package_centos6.jl
@@ -1,0 +1,41 @@
+## This rootfs includes everything that must be installed to build Julia
+## within a CentOS-based environment.
+
+include(joinpath(dirname(@__DIR__), "rootfs_utils.jl"))
+arch, = parse_args(ARGS)
+image = "$(splitext(basename(@__FILE__))[1]).$(arch)"
+
+# Build CentOS-based image with the following extra packages:
+packages = [
+    "automake",
+    "bash",
+    "bison",
+    "cmake",
+    "curl",
+    "flex",
+    "gcc",
+    "gcc-c++",
+    "gcc-gfortran",
+    "gdb",
+    "git",
+    "iproute",
+    "iputils",
+    "less",
+    "libatomic",
+    "libtool",
+    "m4",
+    "make",
+    "perl",
+    "pkgconfig",
+    "vim",
+    "wget",
+]
+tarball_path = centos_bootstrap(image; packages) do rootfs
+    # Print the gcc version to the log
+    chroot(rootfs, "bash", "-c", "gcc --version"; uid=0, gid=0)
+    chroot(rootfs, "bash", "-c", "g++ --version"; uid=0, gid=0)
+    chroot(rootfs, "bash", "-c", "gfortran --version"; uid=0, gid=0)
+end
+
+# Upload it
+upload_rootfs_image_github_actions(tarball_path)

--- a/images/tester_centos6.jl
+++ b/images/tester_centos6.jl
@@ -1,0 +1,16 @@
+## This rootfs does not include the compiler toolchain.
+
+include(joinpath(dirname(@__DIR__), "rootfs_utils.jl"))
+arch, = parse_args(ARGS)
+image = "$(splitext(basename(@__FILE__))[1]).$(arch)"
+
+# Build CentOS-based image with the following extra packages:
+packages = [
+    "bash",
+    "curl",
+    "vim",
+]
+tarball_path = centos_bootstrap(image; packages)
+
+# Upload it
+upload_rootfs_image_github_actions(tarball_path)


### PR DESCRIPTION
Fixes #47
See also: #44

These images are based on CentOS 6. This allows us to build Julia for legacy systems that are using old versions of glibc.

| Image name               | GCC           | glibc |
| ------------------------ | ------------- | ----  |
| `package_centos6.x86_64` | 4.4.7         | 2.12  |
| `tester_centos6.x86_64`  | not installed | 2.12  |