### PR TITLE
README: add a link to the `.buildkite` directory in the Julia repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 [build-url]: https://github.com/JuliaCI/rootfs-images/actions/workflows/build.yml?query=branch%3Amain
 
 The [Base Julia](https://github.com/JuliaLang/julia) CI setup makes use of rootfs images that contain our build tools.
-These rootfs images are built using the fairly simple scripts held within this repository.
 Most images are based on Debian, making use of `debootstrap` to provide a quick and easy rootfs with packages installed through an initial `apt` invocation.
+
+This repository contains the scripts to build the rootfs images.
+The other configuration files for Base Julia CI are located in the [`.buildkite`](https://github.com/JuliaLang/julia/tree/master/.buildkite) directory in the [Julia](https://github.com/JuliaLang/julia) repository.
 
 ## Testing out a rootfs image
 


### PR DESCRIPTION
This repository is home to the rootfs image definitions, but all other CI configuration files live in the `.buildkite` directory in the Julia repository, so we should link to there.

For symmetry, the `.buildkite/README.md` file in the Julia repository already links to this repository.