### PR TITLE
`package_linux`: install both the `python` and `python3` packages from `apt`

### DIFF
--- a/images/package_linux.jl
+++ b/images/package_linux.jl
@@ -22,6 +22,7 @@ packages = [
     "make",
     "perl",
     "pkg-config",
+    "python",
     "python3",
     "wget",
     "vim",


### PR DESCRIPTION
Otherwise, the `llvm_passes` builder (which now uses this image) won't be able to find `python` in the path.