### PR TITLE
`rootfs_utils`: remove the `force_overwrite` keyword argument

### DIFF
--- a/rootfs_utils.jl
+++ b/rootfs_utils.jl
@@ -292,7 +292,6 @@ end
 alpine_bootstrap(name::String; kwargs...) = alpine_bootstrap(p -> nothing, name; kwargs...)
 
 function upload_rootfs_image(tarball_path::String;
-                             force_overwrite::Bool,
                              github_repo::String,
                              tag_name::String,
                              num_retries::Int = 3)
@@ -301,7 +300,6 @@ function upload_rootfs_image(tarball_path::String;
     @info("Uploading to $(github_repo)@$(tag_name)", tarball_url)
     cmd = ghr_jll.ghr()
     append!(cmd.exec, ["-u", dirname(github_repo), "-r", basename(github_repo)])
-    force_overwrite && push!(cmd.exec, "-replace")
     append!(cmd.exec, [tag_name, tarball_path])
     for _ in 1:num_retries
         p = run(cmd)
@@ -363,13 +361,11 @@ function upload_rootfs_image_github_actions(tarball_path::String)
         throw(ErrorException(error_msg))
     end
 
-    force_overwrite = false
     github_repo = get_github_actions_repo()
     tag_name = convert(String, m[1])::String
 
     return upload_rootfs_image(
         tarball_path;
-        force_overwrite,
         github_repo,
         tag_name,
     )


### PR DESCRIPTION
The `force_overwrite` option makes it too easy to accidentally overwrite an existing release artifact.

If a user really needs to overwrite an existing artifact, they can still do so by taking the following steps:
1. Go to https://github.com/JuliaCI/rootfs-images/releases
2. Click on the release in question.
3. Click the "Edit release" button.
4. Scroll down to the bottom of the page, where there is a list of all of the existing artifact files for that release.
5. Next to the artifact file that you want to overwrite, click on the "X" to delete that file.
6. At the bottom of the page, click on the green "Update release" button, which will cause the file to be deleted.
7. Now that the file has been deleted, you can run the `upload_rootfs_image` function to upload the new artifact file.

That all being said, we should try to avoid overwriting existing release artifacts. It's much better to just make a new point release.