### PR TITLE
CI: add a dummy "all" job that depends on all of the actual build jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,12 @@ permissions:
   security-events:     none
   statuses:            none
 jobs:
+  all:
+    name: all
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All build jobs have completed."
   build:
     name: ${{ matrix.image }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
This allows us to simplify our branch protection settings. We can just have the `main` branch require the `all` status check. That way, we don't need to edit the branch protection settings every time we add, remove, or rename an image.