### PR TITLE
CI: after building the image, test that it can be used with Sandbox.jl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,5 +91,6 @@ jobs:
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
           echo "IMAGE_ARCH=$IMAGE_ARCH" >> $GITHUB_ENV
       - run: julia --color=yes --project=. images/${{ env.IMAGE_NAME }}.jl --arch=${{ env.IMAGE_ARCH }}
+        id: build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,5 @@ jobs:
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
           echo "IMAGE_ARCH=$IMAGE_ARCH" >> $GITHUB_ENV
       - run: julia --color=yes --project=. images/${{ env.IMAGE_NAME }}.jl --arch=${{ env.IMAGE_ARCH }}
-        id: build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/images/agent_linux.jl
+++ b/images/agent_linux.jl
@@ -23,7 +23,7 @@ packages = [
     "vim",
 ]
 
-tarball_path = debootstrap(arch, image; packages) do rootfs
+artifact_hash, tarball_path, = debootstrap(arch, image; packages) do rootfs
     # Also download buildkite-agent
     @info("Installing buildkite-agent...")
     buildkite_install_cmd = """
@@ -37,3 +37,6 @@ end
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)
+
+# Test that we can use our new rootfs image with Sandbox.jl
+test_sandbox(artifact_hash)

--- a/images/llvm_passes.jl
+++ b/images/llvm_passes.jl
@@ -20,7 +20,10 @@ packages = [
     "python3",
     "wget",
 ]
-tarball_path = debootstrap(arch, image; packages)
+artifact_hash, tarball_path, = debootstrap(arch, image; packages)
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)
+
+# Test that we can use our new rootfs image with Sandbox.jl
+test_sandbox(artifact_hash)

--- a/images/package_linux.jl
+++ b/images/package_linux.jl
@@ -27,7 +27,7 @@ packages = [
     "wget",
     "vim",
 ]
-tarball_path = debootstrap(arch, image; packages) do rootfs
+artifact_hash, tarball_path, = debootstrap(arch, image; packages) do rootfs
     # Install GCC 9, specifically
     @info("Installing gcc-9")
     gcc_install_cmd = """
@@ -47,3 +47,6 @@ end
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)
+
+# Test that we can use our new rootfs image with Sandbox.jl
+test_sandbox(artifact_hash)

--- a/images/package_linux_qemu.jl
+++ b/images/package_linux_qemu.jl
@@ -30,7 +30,7 @@ packages = [
     "wget",
     "vim",
 ]
-tarball_path = debootstrap(arch, image; packages) do rootfs
+artifact_hash, tarball_path, = debootstrap(arch, image; packages) do rootfs
     # Install GCC 9, specifically
     @info("Installing gcc-9")
     gcc_install_cmd = """
@@ -50,3 +50,6 @@ end
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)
+
+# Test that we can use our new rootfs image with Sandbox.jl
+test_sandbox(artifact_hash)

--- a/images/package_musl.jl
+++ b/images/package_musl.jl
@@ -22,7 +22,10 @@ packages = [
     AlpinePackage("gcc~9", "v3.11"),
     AlpinePackage("gfortran~9", "v3.11"),
 ]
-tarball_path = alpine_bootstrap(image; packages)
+artifact_hash, tarball_path, = alpine_bootstrap(image; packages)
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)
+
+# Test that we can use our new rootfs image with Sandbox.jl
+test_sandbox(artifact_hash)

--- a/images/tester_linux.jl
+++ b/images/tester_linux.jl
@@ -11,7 +11,10 @@ packages = [
     "gdb",
     "vim",
 ]
-tarball_path = debootstrap(arch, image; packages)
+artifact_hash, tarball_path, = debootstrap(arch, image; packages)
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)
+
+# Test that we can use our new rootfs image with Sandbox.jl
+test_sandbox(artifact_hash)

--- a/images/tester_musl.jl
+++ b/images/tester_musl.jl
@@ -11,7 +11,10 @@ packages = [
     AlpinePackage("gdb"),
     AlpinePackage("vim"),
 ]
-tarball_path = alpine_bootstrap(image; packages)
+artifact_hash, tarball_path, = alpine_bootstrap(image; packages)
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)
+
+# Test that we can use our new rootfs image with Sandbox.jl
+test_sandbox(artifact_hash)


### PR DESCRIPTION
This is just a simple sanity check to make sure that the rootfs image that we build can be used with Sandbox.jl.