### PR TITLE
Add the `package_linux_qemu` rootfs images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,15 @@ jobs:
           - 'package_linux.powerpc64le'
           - 'package_linux.x86_64'
 
+          # The `package_linux_qemu` images are all `debian`-based.
+          # They are just like the `package_linux` images, except they also include
+          # `qemu` inside the sandbox.
+          - 'package_linux_qemu.aarch64'
+          - 'package_linux_qemu.armv7l'
+          - 'package_linux_qemu.i686'
+          - 'package_linux_qemu.powerpc64le'
+          - 'package_linux_qemu.x86_64'
+
           # The `package_musl` image is `alpine`-based.
           - 'package_musl.x86_64'
 

--- a/images/package_linux_qemu.jl
+++ b/images/package_linux_qemu.jl
@@ -1,0 +1,52 @@
+## This rootfs includes everything that must be installed to build Julia
+## within a debian-based environment with GCC 9.
+
+include(joinpath(dirname(@__DIR__), "rootfs_utils.jl"))
+arch, = parse_args(ARGS)
+image = "$(splitext(basename(@__FILE__))[1]).$(arch)"
+
+# Build debian-based image with the following extra packages:
+packages = [
+    "automake",
+    "bash",
+    "bison",
+    "cmake",
+    "curl",
+    "flex",
+    "gdb",
+    "git",
+    "less",
+    "libatomic1",
+    "libtool",
+    "m4",
+    "make",
+    "perl",
+    "pkg-config",
+    "python",
+    "python3",
+    "qemu",
+    "qemu-user",
+    "qemu-user-static",
+    "wget",
+    "vim",
+]
+tarball_path = debootstrap(arch, image; packages) do rootfs
+    # Install GCC 9, specifically
+    @info("Installing gcc-9")
+    gcc_install_cmd = """
+    echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list && \\
+    apt-get update && \\
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \\
+        gcc-9 g++-9 gfortran-9
+
+    # Create symlinks for `gcc` -> `gcc-9`, etc...
+    for tool_path in /usr/bin/*-9; do
+        tool="\$(basename "\${tool_path}" | sed -e 's/-9//')"
+        ln -sf "\${tool}-9" "/usr/bin/\${tool}"
+    done
+    """
+    chroot(rootfs, "bash", "-c", gcc_install_cmd; uid=0, gid=0)
+end
+
+# Upload it
+upload_rootfs_image_github_actions(tarball_path)


### PR DESCRIPTION
The `package_linux_qemu` images are just like the `package_linux` images, except that the `package_linux_qemu` images also include `qemu` inside the sandbox.