### PR TITLE
CI: Simplify the `permissions` key in the workflow file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,6 @@ on:
   workflow_dispatch:
 permissions:
   contents:            write
-  actions:             none
-  checks:              none
-  deployments:         none
-  issues:              none
-  discussions:         none
-  packages:            none
-  pull-requests:       none
-  repository-projects: none
-  security-events:     none
-  statuses:            none
 jobs:
   all:
     name: all


### PR DESCRIPTION
According to the GitHub documentation (https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token):

> You can use the `permissions` key in your workflow file to modify permissions for the `GITHUB_TOKEN` for an entire workflow or for individual jobs. This allows you to configure the minimum required permissions for a workflow or job. When the `permissions` key is used, all unspecified permissions are set to no access, with the exception of the `metadata` scope, which always gets read access.

Therefore, if we just set `contents: write`, all of the other permissions will automatically be set to no access.