### PR TITLE
Add the `debian_minimal` rootfs image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
           - 'agent_linux.armv7l'
           - 'agent_linux.ppc64le'
           - 'agent_linux.x86_64'
+          
+          # The `debian_minimal` image is a `debian`-based image that
+          # contains no packages.
+          - 'debian_minimal.x86_64'
 
           # The `package_linux` images are all `debian`-based.
           - 'package_linux.aarch64'

--- a/images/agent_linux.jl
+++ b/images/agent_linux.jl
@@ -17,6 +17,7 @@ packages = [
     # We use these in our buildkite plugins a lot
     "git",
     "jq",
+    "locales",
     "openssl",
     "python3",
     # Debugging

--- a/images/debian_minimal.jl
+++ b/images/debian_minimal.jl
@@ -1,18 +1,10 @@
-## This rootfs does not include the compiler toolchain.
-
 using RootfsUtils
 
 arch, image, = parse_build_args(ARGS, @__FILE__)
 
 # Build debian-based image with the following extra packages:
-packages = [
-    "bash",
-    "curl",
-    "gdb",
-    "locales",
-    "vim",
-]
-artifact_hash, tarball_path, = debootstrap(arch, image; packages)
+packages = String[]
+artifact_hash, tarball_path, = debootstrap(arch, image; packages, locale = false)
 
 # Upload it
 upload_rootfs_image_github_actions(tarball_path)

--- a/images/llvm_passes.jl
+++ b/images/llvm_passes.jl
@@ -13,6 +13,7 @@ packages = [
     "git",
     "less",
     "libatomic1",
+    "locales",
     "m4",
     "perl",
     "pkg-config",

--- a/images/package_linux.jl
+++ b/images/package_linux.jl
@@ -18,6 +18,7 @@ packages = [
     "less",
     "libatomic1",
     "libtool",
+    "locales",
     "m4",
     "make",
     "perl",

--- a/images/package_linux_qemu.jl
+++ b/images/package_linux_qemu.jl
@@ -19,6 +19,7 @@ packages = [
     "less",
     "libatomic1",
     "libtool",
+    "locales",
     "m4",
     "make",
     "perl",


### PR DESCRIPTION
The `debian_minimal` image contains no packages.

We can use this e.g. for testing in the Sandbox.jl test suite. cc: @staticfloat 