### PR TITLE
In the `test_rootfs.jl` script, increase the tmpfs size to 2G

### DIFF
--- a/test_rootfs.jl
+++ b/test_rootfs.jl
@@ -26,6 +26,7 @@ config = SandboxConfig(
     stderr,
     uid=Sandbox.getuid(),
     gid=Sandbox.getgid(),
+    tmpfs_size = "2G",
     multiarch,
 )
 


### PR DESCRIPTION
The default tmpfs size (1G) is not big enough to build Julia from source.