### PR TITLE
Alpine: when downloading the Alpine rootfs, instead of providing a branch name (e.g. `v3.13`), provide the full commit hash

### DIFF
--- a/src/build/alpine.jl
+++ b/src/build/alpine.jl
@@ -5,10 +5,15 @@ function repository_arg(repo)
     return "--repository=http://dl-cdn.alpinelinux.org/alpine/$(repo)/main"
 end
 
-function alpine_bootstrap(f::Function, name::String; release::VersionNumber=v"3.13.6", variant="minirootfs",
-                          packages::Vector{AlpinePackage}=AlpinePackage[], force::Bool=false)
+function alpine_bootstrap(f::Function,
+                          name::String;
+                          force::Bool = false,
+                          git_rev = "97bdddbacbe7f7fa6165ed2bdfa86d7d0ab43420", # v3.13
+                          packages::Vector{AlpinePackage} = AlpinePackage[],
+                          release::VersionNumber = v"3.13.6",
+                          variant::String = "minirootfs")
     return create_rootfs(name; force) do rootfs
-        rootfs_url = "https://github.com/alpinelinux/docker-alpine/raw/v$(release.major).$(release.minor)/x86_64/alpine-$(variant)-$(release)-x86_64.tar.gz"
+        rootfs_url = "https://github.com/alpinelinux/docker-alpine/raw/$(git_rev)/x86_64/alpine-$(variant)-$(release)-x86_64.tar.gz"
         @info("Downloading Alpine rootfs", url=rootfs_url)
         rm(rootfs)
         Pkg.Artifacts.download_verify_unpack(rootfs_url, nothing, rootfs; verbose=true)


### PR DESCRIPTION
This will prevent CI from randomly breaking because they changed something upstream.