### PR TITLE
`test_rootfs.jl` script: default to a tmpfs size of 1G

### DIFF
--- a/src/test_img/args.jl
+++ b/src/test_img/args.jl
@@ -28,7 +28,7 @@ function parse_test_args(args::AbstractVector, file::AbstractString)
         "--tmpfs-size"
             arg_type = String
             required = false
-            default = "2G"
+            default = "1G"
             help = "Size of the temporary filesystem."
         "--treehash", "-t"
             arg_type = String


### PR DESCRIPTION
Now that we have the optional `--tmpfs-size` command-line argument, it is easy for users to set whatever tmpfs size they want. So let's default to something smaller, i.e. 1G, and users that need more can easily set a larger tmpfs size.