### PR TITLE
Add an example of using CI to build a Windows Docker image

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,15 +14,15 @@ permissions:
 concurrency:
   # Skip intermediate builds: always.
   # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   linux:
     name: linux
-    needs: build_linux # these jobs must complete successfully
+    needs: build_linux
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All build jobs have completed successfully."
+      - run: true
   build_linux:
     name: build_linux / ${{ matrix.image }}
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,44 @@
+name: Windows
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+  workflow_dispatch:
+permissions:
+  contents: none
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  windows:
+    name: windows
+    needs: build_windows
+    runs-on: windows-latest
+    steps:
+      - run: true
+  build_windows:
+    name: build_windows / ${{ matrix.image }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - 'package_win32'
+          - 'package_win64'
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker --version
+      - run: docker build -t ${{ matrix.image }} .
+        working-directory: windows/${{ matrix.image }}
+      - run: docker images ${{ matrix.image }} --no-trunc
+      - run: docker images ${{ matrix.image }} --digests
+      - run: docker inspect ${{ matrix.image }}
+      - run: docker run -d ${{ matrix.image }}
+      - run: docker ps

--- a/windows/package_win32/Dockerfile
+++ b/windows/package_win32/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/windows/servercore/iis
+
+WORKDIR /build

--- a/windows/package_win64/Dockerfile
+++ b/windows/package_win64/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/windows/servercore/iis
+
+WORKDIR /build


### PR DESCRIPTION
This is just a really simple example to demonstrate that we can use GitHub Actions to build Docker images with Docker for Windows.