### PR TITLE
Add the ability to skip tarball creation when developing locally

### DIFF
--- a/linux/agent_linux.jl
+++ b/linux/agent_linux.jl
@@ -1,31 +1,25 @@
-## This rootfs includes just enough of the tools for our buildkite agent
-## to run inside of.  Most CI steps will be run within a different image
-## nested inside of this one.
-
 using RootfsUtils: parse_build_args, debootstrap, chroot, upload_gha, test_sandbox
 
-arch, image, = parse_build_args(ARGS, @__FILE__)
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
 
-# Build debian-based image with the following extra packages:
 packages = [
-    # General package getting/installing packages
     "apt-transport-https",
     "curl",
-    "gnupg2",
-    "openssh-client",
-    "wget",
-    # We use these in our buildkite plugins a lot
     "git",
+    "gnupg2",
     "jq",
     "locales",
+    "openssh-client",
     "openssl",
     "python3",
-    # Debugging
     "vim",
+    "wget",
 ]
 
-artifact_hash, tarball_path, = debootstrap(arch, image; packages) do rootfs
-    # Also download buildkite-agent
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do rootfs
     @info("Installing buildkite-agent...")
     buildkite_install_cmd = """
     echo 'deb https://apt.buildkite.com/buildkite-agent stable main' >> /etc/apt/sources.list && \\
@@ -36,8 +30,5 @@ artifact_hash, tarball_path, = debootstrap(arch, image; packages) do rootfs
     chroot(rootfs, "bash", "-c", buildkite_install_cmd; uid=0, gid=0)
 end
 
-# Upload it
 upload_gha(tarball_path)
-
-# Test that we can use our new rootfs image with Sandbox.jl
 test_sandbox(artifact_hash)

--- a/linux/debian_minimal.jl
+++ b/linux/debian_minimal.jl
@@ -1,13 +1,13 @@
 using RootfsUtils: parse_build_args, debootstrap, chroot, upload_gha, test_sandbox
 
-arch, image, = parse_build_args(ARGS, @__FILE__)
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
 
-# Build debian-based image with the following extra packages:
 packages = String[]
-artifact_hash, tarball_path, = debootstrap(arch, image; packages, locale = false)
+locale = false
 
-# Upload it
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, locale)
 upload_gha(tarball_path)
-
-# Test that we can use our new rootfs image with Sandbox.jl
 test_sandbox(artifact_hash)

--- a/linux/llvm_passes.jl
+++ b/linux/llvm_passes.jl
@@ -1,10 +1,10 @@
-## This rootfs includes enough of a host toolchain to build the LLVM passes (such as `analyzegc`).
-
 using RootfsUtils: parse_build_args, debootstrap, chroot, upload_gha, test_sandbox
 
-arch, image, = parse_build_args(ARGS, @__FILE__)
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
 
-# Build debian-based image with the following extra packages:
 packages = [
     "build-essential",
     "cmake",
@@ -21,10 +21,7 @@ packages = [
     "python3",
     "wget",
 ]
-artifact_hash, tarball_path, = debootstrap(arch, image; packages)
 
-# Upload it
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
 upload_gha(tarball_path)
-
-# Test that we can use our new rootfs image with Sandbox.jl
 test_sandbox(artifact_hash)

--- a/linux/package_musl.jl
+++ b/linux/package_musl.jl
@@ -1,16 +1,13 @@
-## This rootfs includes everything that must be installed to build Julia
-## within an alpine-based environment with GCC 9.
-
 using RootfsUtils: AlpinePackage, parse_build_args, alpine_bootstrap, chroot, upload_gha, test_sandbox
 
-arch, image, = parse_build_args(ARGS, @__FILE__)
+args         = parse_build_args(ARGS, @__FILE__)
+archive      = args.archive
+image        = args.image
 
-# Build alpine-based image with the following extra packages:
 packages = [
     AlpinePackage("bash"),
     AlpinePackage("cmake"),
     AlpinePackage("curl"),
-    AlpinePackage("gdb"),
     AlpinePackage("git"),
     AlpinePackage("less"),
     AlpinePackage("lldb"),
@@ -19,15 +16,12 @@ packages = [
     AlpinePackage("python3"),
     AlpinePackage("wget"),
 
-    # Install gcc/g++/gfortran v9, which comes from the Alpine v3.11 line
     AlpinePackage("g++~9", "v3.11"),
     AlpinePackage("gcc~9", "v3.11"),
+    AlpinePackage("gdb"),
     AlpinePackage("gfortran~9", "v3.11"),
 ]
-artifact_hash, tarball_path, = alpine_bootstrap(image; packages)
 
-# Upload it
+artifact_hash, tarball_path, = alpine_bootstrap(image; archive, packages)
 upload_gha(tarball_path)
-
-# Test that we can use our new rootfs image with Sandbox.jl
 test_sandbox(artifact_hash)

--- a/linux/pkgserver_logsync.jl
+++ b/linux/pkgserver_logsync.jl
@@ -1,21 +1,20 @@
 using RootfsUtils: parse_build_args, debootstrap, chroot, upload_gha, test_sandbox
 
-arch, image, = parse_build_args(ARGS, @__FILE__)
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
 
-# Build debian-based image with the following extra packages:
 packages = String[
-    "openssh-client",
     "awscli",
-    "rsync",
     "curl",
     "jq",
-    "zstd",
     "locales",
+    "openssh-client",
+    "rsync",
+    "zstd",
 ]
-artifact_hash, tarball_path, = debootstrap(arch, image; packages)
 
-# Upload it
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
 upload_gha(tarball_path)
-
-# Test that we can use our new rootfs image with Sandbox.jl
 test_sandbox(artifact_hash)

--- a/linux/tester_linux.jl
+++ b/linux/tester_linux.jl
@@ -1,10 +1,10 @@
-## This rootfs does not include the compiler toolchain.
-
 using RootfsUtils: parse_build_args, debootstrap, chroot, upload_gha, test_sandbox
 
-arch, image, = parse_build_args(ARGS, @__FILE__)
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
 
-# Build debian-based image with the following extra packages:
 packages = [
     "bash",
     "curl",
@@ -12,10 +12,7 @@ packages = [
     "locales",
     "vim",
 ]
-artifact_hash, tarball_path, = debootstrap(arch, image; packages)
 
-# Upload it
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
 upload_gha(tarball_path)
-
-# Test that we can use our new rootfs image with Sandbox.jl
 test_sandbox(artifact_hash)

--- a/linux/tester_musl.jl
+++ b/linux/tester_musl.jl
@@ -1,20 +1,18 @@
-## This rootfs does not include the compiler toolchain.
-
 using RootfsUtils: AlpinePackage, parse_build_args, alpine_bootstrap, chroot, upload_gha, test_sandbox
 
-arch, image, = parse_build_args(ARGS, @__FILE__)
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
 
-# Build alpine-based image with the following extra packages:
+# Build alpine-based args.image with the following extra packages:
 packages = [
     AlpinePackage("bash"),
     AlpinePackage("curl"),
     AlpinePackage("gdb"),
     AlpinePackage("vim"),
 ]
-artifact_hash, tarball_path, = alpine_bootstrap(image; packages)
 
-# Upload it
+artifact_hash, tarball_path, = alpine_bootstrap(image; archive, packages)
 upload_gha(tarball_path)
-
-# Test that we can use our new rootfs image with Sandbox.jl
 test_sandbox(artifact_hash)

--- a/src/build_img/alpine.jl
+++ b/src/build_img/alpine.jl
@@ -5,14 +5,14 @@ function repository_arg(repo)
     return "--repository=http://dl-cdn.alpinelinux.org/alpine/$(repo)/main"
 end
 
-function alpine_bootstrap(f::Function,
-                          name::String;
+function alpine_bootstrap(f::Function, name::String;
+                          archive::Bool = true,
                           force::Bool = false,
                           git_rev = "97bdddbacbe7f7fa6165ed2bdfa86d7d0ab43420", # v3.13
                           packages::Vector{AlpinePackage} = AlpinePackage[],
                           release::VersionNumber = v"3.13.6",
                           variant::String = "minirootfs")
-    return create_rootfs(name; force) do rootfs
+    return create_rootfs(name; archive, force) do rootfs
         rootfs_url = "https://github.com/alpinelinux/docker-alpine/raw/$(git_rev)/x86_64/alpine-$(variant)-$(release)-x86_64.tar.gz"
         @info("Downloading Alpine rootfs", url=rootfs_url)
         rm(rootfs)

--- a/src/build_img/args.jl
+++ b/src/build_img/args.jl
@@ -11,10 +11,14 @@ function parse_build_args(args::AbstractVector, file::AbstractString)
             arg_type = String
             required = true
             help = "The architecture for which you would like to build"
+        "--no-archive"
+            action = :store_true
+            help = "When this flag is provided, the .tar.gz archive will not be created"
     end
     parsed_args = ArgParse.parse_args(args, settings)
-    # arch = parsed_args["arch"]
-    arch = _process_required_string_arg(parsed_args, "arch")
-    image = generate_image_name(arch, file)
-    return (; arch, image)
+    arch = _process_required_string_arg(parsed_args, "arch")::String
+    image = generate_image_name(arch, file)::String
+    no_archive = parsed_args["no-archive"]::Bool
+    archive = !no_archive
+    return (; arch, archive, image)
 end

--- a/src/build_img/debian.jl
+++ b/src/build_img/debian.jl
@@ -10,6 +10,7 @@ function debian_arch(image_arch::String)
 end
 
 function debootstrap(f::Function, arch::String, name::String;
+                     archive::Bool = true,
                      force::Bool = false,
                      locale::Bool = true,
                      packages::Vector{String} = String[],
@@ -37,7 +38,7 @@ function debootstrap(f::Function, arch::String, name::String;
         error("Must install qemu-user-static and binfmt_misc!")
     end
 
-    return create_rootfs(name; force) do rootfs
+    return create_rootfs(name; archive, force) do rootfs
         @info("Running debootstrap", release, variant, packages)
         debootstrap_cmd = `sudo debootstrap`
         push!(debootstrap_cmd.exec, "--arch=$(debian_arch(arch))")

--- a/test_rootfs.jl
+++ b/test_rootfs.jl
@@ -3,7 +3,6 @@ using RootfsUtils: parse_test_args, ensure_artifact_exists_locally
 using Sandbox: Sandbox, SandboxConfig, with_executor
 
 args            = parse_test_args(ARGS, @__FILE__)
-
 command         = args.command
 multiarch       = args.multiarch
 read_write_maps = args.read_write_maps


### PR DESCRIPTION
### Description

This PR adds the optional `--no-archive` command-line flag when building rootfs images. This flag does not take any arguments.

When the `--no-archive` command-line flag is NOT provided (the default behavior), then the tarball WILL be created.

When the `--no-archive` command-line flag is provided, then the tarball will NOT be created.

### Motivation

When I'm working locally, my workflow looks like this:
1. Build the rootfs image
2. Enter the rootfs image, and run some commands (e.g. try to build Julia or run the Julia tests)
3. Encounter some kind of problem
4. Edit the rootfs image definition
5. Re-build the rootfs image with the new definition
6. Enter the new rootfs image
7. Repeat the cycle

When working in this cycle, I don't actually need to create the tarball files. So it's much faster for me if I can skip the tarball creation.