### PR TITLE
Add `aws_uploader` rootfs definition

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,6 +40,11 @@ jobs:
           # contains no packages.
           - 'debian_minimal.x86_64'
 
+          # The `aws_uploader` image is a `debian`-based image that
+          # contains just `awscli`, for usage in secured pipelines
+          # that need to upload to AWS.
+          - 'aws_uploader.x86_64'
+
           # The `package_linux` images are all `debian`-based.
           - 'package_linux.aarch64'
           - 'package_linux.armv7l'

--- a/linux/aws_uploader.jl
+++ b/linux/aws_uploader.jl
@@ -1,0 +1,19 @@
+using RootfsUtils: parse_build_args, debootstrap, chroot, upload_gha, test_sandbox
+
+arch, image, = parse_build_args(ARGS, @__FILE__)
+
+# Build debian-based image with the following extra packages:
+packages = [
+    "awscli",
+    "bash",
+    "curl",
+    "locales",
+    "vim",
+]
+artifact_hash, tarball_path = debootstrap(arch, image; packages)
+
+# Upload it
+upload_gha(tarball_path)
+
+# Test that we can use our new rootfs image with Sandbox.jl
+test_sandbox(artifact_hash)


### PR DESCRIPTION
Oftentimes, we separate our jobs into two stages:

- build, which requires host toolchains, but has no access to secrets
- upload, which does not require host toolchains, but does have access to secrets

This rootfs image is intended for usage in the second stage, when we
have access to secrets and need to upload things to S3.