### PR TITLE
Add `python_latex_kitchen_sink` image

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -72,8 +72,16 @@ jobs:
 
           # The `pkgserver_logsync` image is a helper for https://github.com/JuliaPackaging/PkgServerLogAnalysis.jl
           - 'pkgserver_logsync.x86_64'
-          
+         
+          # The `npm_linux` image is a helper for ecosystem jobs that need to build NPM packages 
           - 'npm_linux.x86_64'
+
+          # The `python_latex_kitchen_sink` image is a helper for ecosystem jobs, such as SciMLBenchmarks
+          # that require a large number of tools.  We're kind of throwing everything (including, yes, the
+          # proverbial  kitchen sink) in here, in the hope that we'll be able to re-use this image across
+          # many similar jobs.  If you're using this image, you're throwing in the towel on providing a
+          # small, lean environment, but that's probably necessary.
+          - 'python_latex_kitchen_sink.x86_64'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/linux/python_latex_kitchen_sink.jl
+++ b/linux/python_latex_kitchen_sink.jl
@@ -1,0 +1,38 @@
+# This image is a bit of an anomaly; we install pdflatex, python3.... pretty much the kitchen sink
+# It is used by pipelines that use the SciML ecosystem such as the SciMLBenchmarks repository.
+using RootfsUtils: parse_build_args, debootstrap, chroot, upload_gha, test_sandbox
+
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
+
+packages = [
+    "bash",
+    "locales",
+    
+    # Work around bug in debootstrap where virtual dependencies are not properly installed
+    # X-ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=878961
+    # X-ref: https://bugs.launchpad.net/ubuntu/+source/debootstrap/+bug/86536
+    "perl-openssl-defaults",
+    "dbus-user-session",
+    "python3-sip",
+
+
+    # Get a C compiler, for compiling python extensions
+    "build-essential",
+    # Get latex, so that we can invoke `pdflatex` and friends
+    "texlive-full",
+    # Some of our packages require PyCall.jl/Conda.jl deps
+    "python3",
+    "liblapack3",
+
+    # These are just for debugging
+    "curl",
+    "vim",
+    "gdb",
+]
+
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
+upload_gha(tarball_path)
+test_sandbox(artifact_hash)


### PR DESCRIPTION
The `python_latex_kitchen_sink` image is a helper for ecosystem jobs, such as SciMLBenchmarks that require a large number of tools.  We're kind of throwing everything (including, yes, the proverbial  kitchen sink) in here, in the hope that we'll be able to re-use this image across many similar jobs.  If you're using this image, you're throwing in the towel on providing a small, lean environment, but that's probably necessary.