### PR TITLE
Add `lldb` to every rootfs image that currently has `gdb`

### DIFF
--- a/linux/python_latex_kitchen_sink.jl
+++ b/linux/python_latex_kitchen_sink.jl
@@ -33,6 +33,7 @@ packages = [
     "curl",
     "vim",
     "gdb",
+    "lldb",
 ]
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)

--- a/linux/tester_linux.jl
+++ b/linux/tester_linux.jl
@@ -10,6 +10,7 @@ packages = [
     "bash",
     "curl",
     "gdb",
+    "lldb",
     "locales",
     "vim",
 ]

--- a/linux/tester_musl.jl
+++ b/linux/tester_musl.jl
@@ -10,6 +10,7 @@ packages = [
     AlpinePackage("bash"),
     AlpinePackage("curl"),
     AlpinePackage("gdb"),
+    AlpinePackage("lldb"),
     AlpinePackage("vim"),
 ]
 


### PR DESCRIPTION
I know that some people prefer to use `lldb` instead of `gdb`. So let's give the user the choice