### PR TITLE
Add `zip` to python_latex_kitchen_sink

### DIFF
--- a/linux/python_latex_kitchen_sink.jl
+++ b/linux/python_latex_kitchen_sink.jl
@@ -12,6 +12,7 @@ image        = args.image
 packages = [
     "bash",
     "locales",
+    "zip",
 
     # Work around bug in debootstrap where virtual dependencies are not properly installed
     # X-ref: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=878961


### PR DESCRIPTION
`zip` is required for certain SciML tests