### PR TITLE
CI: increase the per-job timeout to 2 hours

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   linux:
-    timeout-minutes: 60
+    timeout-minutes: 120
     name: linux
     needs: build_linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
The "kitchen sink" image may take up to 1.5 hours. So, just to be safe, let's increase the timeout (for each Linux job) to 2 hours.