### PR TITLE
Keep `true` as the default value for the `--override-tmp-dir` flag

### DIFF
--- a/src/test_img/args.jl
+++ b/src/test_img/args.jl
@@ -23,7 +23,7 @@ function parse_test_args(args::AbstractVector, file::AbstractString)
         "--override-tmp-dir"
             arg_type = Bool
             required = false
-            default = true # TODO: change this to false
+            default = true
             help = string(
                 "Whether to create a mapping for /tmp. ",
                 "Possible values: true, false.",


### PR DESCRIPTION
After all, the `--override-tmp-dir` flag is just for the `test_rootfs.jl` script, so I think it's fine for `--override-tmp-dir true` to be the default.

It's easy enough for the user to pass `--override-tmp-dir false` if they don't like the default value.