### PR TITLE
Add the `chroot_command` and `root_chroot_command` utility functions for constructing the `Cmd` objects but not actually running them

### DIFF
--- a/src/utils/chroot.jl
+++ b/src/utils/chroot.jl
@@ -3,9 +3,16 @@
 getuid() = ccall(:getuid, Cint, ())
 getgid() = ccall(:getgid, Cint, ())
 
-function chroot(rootfs, cmds...; ENV::AbstractDict, uid=getuid(), gid=getgid())
+function chroot_command(rootfs, cmds...; ENV::AbstractDict, uid=getuid(), gid=getgid())
     command = `sudo chroot --userspec=$(uid):$(gid) $(rootfs) $(cmds)`
-    return run(setenv(command, ENV))
+    return setenv(command, ENV)
 end
 
-root_chroot(args...; ENV::AbstractDict) = chroot(args...; ENV, uid=0, gid=0)
+function root_chroot_command(varargs...; ENV::AbstractDict)
+    uid = 0
+    gid = 0
+    return chroot_command(varargs...; ENV, uid, gid)
+end
+
+chroot(varargs...; kwargs...)      = run(chroot_command(varargs...; kwargs...))
+root_chroot(varargs...; kwargs...) = run(root_chroot_command(varargs...; kwargs...))


### PR DESCRIPTION
This can be useful if e.g. you want to `read(cmd, String)` instead of just doing `run(cmd)`.