### PR TITLE
Reduce some duplication when using the `root_chroot` function

### DIFF
--- a/linux/agent_linux.jl
+++ b/linux/agent_linux.jl
@@ -22,7 +22,7 @@ packages = [
 ]
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do rootfs, chroot_ENV
-    my_chroot(args...) = root_chroot(args...; ENV=chroot_ENV)
+    my_chroot(args...) = root_chroot(rootfs, "bash", "-c", args...; ENV=chroot_ENV)
 
     @info("Installing buildkite-agent...")
     buildkite_install_cmd = """
@@ -31,10 +31,10 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
     apt-get update && \\
     DEBIAN_FRONTEND=noninteractive apt-get install -y buildkite-agent
     """
-    my_chroot(rootfs, "bash", "-c", buildkite_install_cmd)
-    my_chroot(rootfs, "bash", "-c", "which buildkite-agent")
-    my_chroot(rootfs, "bash", "-c", "which -a buildkite-agent")
-    my_chroot(rootfs, "bash", "-c", "buildkite-agent --help")
+    my_chroot(buildkite_install_cmd)
+    my_chroot("which buildkite-agent")
+    my_chroot("which -a buildkite-agent")
+    my_chroot("buildkite-agent --help")
 
     @info("Installing yq...")
     yq_install_cmd = """
@@ -44,10 +44,10 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
     cd / && \\
     rm -rfv /tmp-install-yq
     """
-    my_chroot(rootfs, "bash", "-c", yq_install_cmd)
-    my_chroot(rootfs, "bash", "-c", "which yq")
-    my_chroot(rootfs, "bash", "-c", "which -a yq")
-    my_chroot(rootfs, "bash", "-c", "yq --version")
+    my_chroot(yq_install_cmd)
+    my_chroot("which yq")
+    my_chroot("which -a yq")
+    my_chroot("yq --version")
 end
 
 upload_gha(tarball_path)

--- a/linux/package_linux.jl
+++ b/linux/package_linux.jl
@@ -35,7 +35,7 @@ packages = [
 ]
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do rootfs, chroot_ENV
-    my_chroot(args...) = root_chroot(args...; ENV=chroot_ENV)
+    my_chroot(args...) = root_chroot(rootfs, "bash", "-c", args...; ENV=chroot_ENV)
 
     # Install GCC 9, specifically
     @info("Installing gcc-9")
@@ -51,17 +51,17 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
         ln -sf "\${tool}-9" "/usr/bin/\${tool}"
     done
     """
-    my_chroot(rootfs, "bash", "-c", gcc_install_cmd)
-    my_chroot(rootfs, "bash", "-c", gcc_symlink_cmd)
-    my_chroot(rootfs, "bash", "-c", "which gcc")
-    my_chroot(rootfs, "bash", "-c", "which -a gcc")
-    my_chroot(rootfs, "bash", "-c", "which g++")
-    my_chroot(rootfs, "bash", "-c", "which -a g++")
-    my_chroot(rootfs, "bash", "-c", "which gfortran")
-    my_chroot(rootfs, "bash", "-c", "which -a gfortran")
-    my_chroot(rootfs, "bash", "-c", "gcc --version")
-    my_chroot(rootfs, "bash", "-c", "g++ --version")
-    my_chroot(rootfs, "bash", "-c", "gfortran --version")
+    my_chroot(gcc_install_cmd)
+    my_chroot(gcc_symlink_cmd)
+    my_chroot("which gcc")
+    my_chroot("which -a gcc")
+    my_chroot("which g++")
+    my_chroot("which -a g++")
+    my_chroot("which gfortran")
+    my_chroot("which -a gfortran")
+    my_chroot("gcc --version")
+    my_chroot("g++ --version")
+    my_chroot("gfortran --version")
 end
 
 upload_gha(tarball_path)

--- a/linux/rr.jl
+++ b/linux/rr.jl
@@ -31,16 +31,15 @@ packages = [
 release = "bookworm"
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, release) do rootfs, chroot_ENV
-    my_chroot(args...)         = root_chroot(rootfs, args...; ENV=chroot_ENV)
-    my_chroot_command(args...) = root_chroot_command(rootfs, args...; ENV=chroot_ENV)
+    my_chroot(args...)         = root_chroot(        "bash", "-c", rootfs, args...; ENV=chroot_ENV)
+    my_chroot_command(args...) = root_chroot_command("bash", "-c", rootfs, args...; ENV=chroot_ENV)
 
-    my_chroot("bash", "-c", "apt-get update")
-    my_chroot("bash", "-c", "DEBIAN_FRONTEND=noninteractive apt-get install -y gdb")
-
-    my_chroot("bash", "-c", "cmake --version")
+    my_chroot("apt-get update")
+    my_chroot("DEBIAN_FRONTEND=noninteractive apt-get install -y gdb")
+    my_chroot("cmake --version")
 
     let
-        str = read(my_chroot_command("bash", "-c", "cmake --version"), String)
+        str = read(my_chroot_command("cmake --version"), String)
         m = match(r"cmake version ([\d]*)\.([\d]*)\.([\d]*)", str)
         installed_ver = VersionNumber("$(m[1]).$(m[2]).$(m[3])")
         desired_ver = v"3.22.1"


### PR DESCRIPTION
This should make calls to the `my_chroot` closures less verbose and more readable.