### PR TITLE
Add a rootfs-image that has Julia already installed inside it

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,62 +32,50 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          # Build a bunch of different "agent" rootfs images.
-          - 'agent_linux.aarch64'
-          - 'agent_linux.armv7l'
-          - 'agent_linux.ppc64le'
-          - 'agent_linux.x86_64'
+#           - 'agent_linux.aarch64'
+#           - 'agent_linux.armv7l'
+#           - 'agent_linux.ppc64le'
+#           - 'agent_linux.x86_64'
 
-          # The `debian_minimal` image is a `debian`-based image that
-          # contains no packages.
-          - 'debian_minimal.x86_64'
+#           - 'aws_uploader.x86_64'
 
-          # The `aws_uploader` image is a `debian`-based image that
-          # contains just `awscli`, for usage in secured pipelines
-          # that need to upload to AWS.
-          - 'aws_uploader.x86_64'
+#           - 'debian_minimal.x86_64'
 
-          # The `package_linux` images are all `debian`-based.
-          # - 'package_linux.aarch64'
-          - 'package_linux.armv7l'
-          - 'package_linux.i686'
-          - 'package_linux.powerpc64le'
-          - 'package_linux.x86_64'
+          # - 'julia.aarch64' # Issue 131
+          - 'julia.armv7l'
+          - 'julia.i686'
+          - 'julia.x86_64'
 
-          # The `package_musl` image is `alpine`-based.
-          - 'package_musl.x86_64'
+#           # - 'package_linux.aarch64' # Issue 131
+#           - 'package_linux.armv7l'
+#           - 'package_linux.i686'
+#           - 'package_linux.powerpc64le'
+#           - 'package_linux.x86_64'
 
-          # The `rr` image is `debian`-based.
-          # It is used for building rr from source and running the rr test suite.
-          - 'rr.x86_64'
+#           - 'package_musl.x86_64'
 
-          # The `tester_linux` images are all `debian`-based.
-          # They do not include the compiler toolchain.
-          - 'tester_linux.aarch64'
-          - 'tester_linux.armv7l'
-          - 'tester_linux.i686'
-          - 'tester_linux.powerpc64le'
-          - 'tester_linux.x86_64'
+#           - 'llvm_passes.x86_64'
 
-          # The `tester_musl` image is `alpine`-based.
-          # It does not include the compiler toolchain.
-          - 'tester_musl.x86_64'
+#           - 'npm_linux.x86_64'
 
-          # The `llvm_passes` image is a short-term solution for the `analyzegc` builder.
-          - 'llvm_passes.x86_64'
+#           - 'pkgserver_logsync.x86_64'
 
-          # The `pkgserver_logsync` image is a helper for https://github.com/JuliaPackaging/PkgServerLogAnalysis.jl
-          - 'pkgserver_logsync.x86_64'
+#           - 'rr.x86_64'
 
-          # The `npm_linux` image is a helper for ecosystem jobs that need to build NPM packages
-          - 'npm_linux.x86_64'
+#           - 'tester_linux.aarch64'
+#           - 'tester_linux.armv7l'
+#           - 'tester_linux.i686'
+#           - 'tester_linux.powerpc64le'
+#           - 'tester_linux.x86_64'
+
+#           - 'tester_musl.x86_64'
 
           # The `python_latex_kitchen_sink` image is a helper for ecosystem jobs, such as SciMLBenchmarks
           # that require a large number of tools.  We're kind of throwing everything (including, yes, the
           # proverbial  kitchen sink) in here, in the hope that we'll be able to re-use this image across
           # many similar jobs.  If you're using this image, you're throwing in the towel on providing a
           # small, lean environment, but that's probably necessary.
-          - 'python_latex_kitchen_sink.x86_64'
+#           - 'python_latex_kitchen_sink.x86_64'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/linux/julia.jl
+++ b/linux/julia.jl
@@ -1,0 +1,80 @@
+using RootfsUtils: parse_build_args, upload_gha, test_sandbox
+using RootfsUtils: debootstrap
+using RootfsUtils: root_chroot
+
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
+
+julia_version_number = v"1.7.2"
+
+packages = [
+    "build-essential",
+    "bzip2",
+    "cmake",
+    "curl",
+    "gfortran",
+    "git",
+    "less",
+    "libatomic1",
+    "locales",
+    "m4",
+    "perl",
+    "pkg-config",
+    "python",
+    "python3",
+    "wget",
+]
+
+julia_longarch_dict = Dict(
+    "aarch64" => "aarch64",
+    "armv7l"  => "",
+    "i686"    => "i686",
+    "x86_64"  => "x86_64",
+)
+
+julia_shortarch_dict = Dict(
+    "aarch64" => "aarch64",
+    "armv7l"  => "armv7l",
+    "i686"    => "x86",
+    "x86_64"  => "x64",
+)
+
+julia_longarch  = julia_longarch_dict[arch]
+julia_shortarch = julia_shortarch_dict[arch]
+julia_major = julia_version_number.major
+julia_minor = julia_version_number.minor
+julia_patch = julia_version_number.patch
+julia_majmin = "$(julia_major).$(julia_minor)"
+julia_version_str = "$(julia_major).$(julia_minor).$(julia_patch)"
+julia_tarball = "julia-$(julia_version_str)-linux-$(julia_longarch).tar.gz"
+julia_url = "https://julialang-s3.julialang.org/bin/linux/$(julia_shortarch)/$(julia_majmin)/$(julia_tarball)"
+
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do rootfs, chroot_ENV
+    my_chroot(args...) = root_chroot(rootfs, "bash", "-c", args...; ENV=chroot_ENV)
+
+    @info "Downloading Julia from: $(julia_url)"
+    julia_install_cmd = """
+    mkdir /tmp-install-julia && \\
+    cd /tmp-install-julia && \\
+    wget $(julia_url)
+    tar xzvf $(julia_tarball)
+    rm $(julia_tarball)
+    mv julia-$(julia_version_str) julia
+    mkdir -p /opt
+    mv julia /opt
+    cd / && \\
+    rm -rfv /tmp-install-julia
+    """
+    my_chroot(julia_install_cmd)
+    my_chroot("mkdir -p /usr/local/bin")
+    my_chroot("ln -s /opt/julia/bin/julia /usr/local/bin/julia")
+    my_chroot("which julia")
+    my_chroot("which -a julia")
+    my_chroot("julia --version")
+    my_chroot("julia -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'")
+end
+
+upload_gha(tarball_path)
+test_sandbox(artifact_hash)

--- a/linux/julia.jl
+++ b/linux/julia.jl
@@ -29,7 +29,7 @@ packages = [
 
 julia_longarch_dict = Dict(
     "aarch64" => "aarch64",
-    "armv7l"  => "",
+    "armv7l"  => "armv7l",
     "i686"    => "i686",
     "x86_64"  => "x86_64",
 )

--- a/linux/julia.jl
+++ b/linux/julia.jl
@@ -58,8 +58,8 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
     julia_install_cmd = """
     mkdir /tmp-install-julia && \\
     cd /tmp-install-julia && \\
-    wget $(julia_url)
-    tar xzvf $(julia_tarball)
+    wget --no-verbose $(julia_url)
+    tar xzf $(julia_tarball)
     rm $(julia_tarball)
     mv julia-$(julia_version_str) julia
     mkdir -p /opt


### PR DESCRIPTION
Sometimes, you want to test the nested sandboxes locally. But in order to do so, you need to install Julia inside the first (outer) sandbox.

On Buildkite, we have the [`JuliaCI/julia-buildkite-plugin`](https://github.com/JuliaCI/julia-buildkite-plugin) plugin. But locally, we don't have that. So let's make a rootfs image that already has Julia installed inside it.