### PR TITLE
`test_rootfs.jl`: add a command-line option to automatically mount Julia from the outside world into the sandbox

### DIFF
--- a/src/test_img/args.jl
+++ b/src/test_img/args.jl
@@ -20,6 +20,14 @@ function parse_test_args(args::AbstractVector, file::AbstractString)
                 "Whether to map a persistant build directory into the sandbox. ",
                 "Possible values: persist, temp, no.",
             )
+        "--mount-julia"
+            arg_type = Bool
+            required = false
+            default = false
+            help = string(
+                "Whether to mount the current Julia binary into the sandbox. ",
+                "Possible values: true, false.",
+            )
         "--override-tmp-dir"
             arg_type = Bool
             required = false
@@ -51,7 +59,8 @@ function parse_test_args(args::AbstractVector, file::AbstractString)
     end
     parsed_args = ArgParse.parse_args(args, settings)
 
-    override_tmp_dir = parsed_args["override-tmp-dir"]::Bool
+    mount_julia       = parsed_args["mount-julia"]::Bool
+    override_tmp_dir  = parsed_args["override-tmp-dir"]::Bool
 
     map_build_dir     = _process_required_string_arg(  parsed_args, "map-build-dir")
     tmpfs_size        = _process_required_string_arg(  parsed_args, "tmpfs-size")
@@ -97,6 +106,7 @@ function parse_test_args(args::AbstractVector, file::AbstractString)
 
     result = (;
         command,
+        mount_julia,
         multiarch,
         read_write_maps,
         tmpfs_size,

--- a/test_rootfs.jl
+++ b/test_rootfs.jl
@@ -4,7 +4,7 @@ using Sandbox: Sandbox, SandboxConfig, with_executor
 
 args            = parse_test_args(ARGS, @__FILE__)
 command         = args.command
-mount_julia     = args.mount_julia # TODO: implement this line
+mount_julia     = args.mount_julia
 multiarch       = args.multiarch
 read_write_maps = args.read_write_maps
 tmpfs_size      = args.tmpfs_size


### PR DESCRIPTION
Closes #164 

The user can of course do this manually, but it's nice to be able to automate it.