### PR TITLE
Use custom GCC 9 and glibc 2.12.2 for `package_linux` on `x86_64-linux-gnu`

### DIFF
--- a/linux/package_linux.jl
+++ b/linux/package_linux.jl
@@ -51,7 +51,7 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
         curl -L $(repo_release_url)/LinuxKernelHeaders.v5.15.14.x86_64-linux-target_os+linux-target_arch+x86_64.tar.gz | tar zx
         """
         gcc_symlink_cmd = """
-        # Create symlinks for `gcc` -> `gcc-9`, etc...
+        # Create symlinks for `gcc` -> `x86_64-linux-gnu-gcc`, etc...
         for tool_path in /usr/local/bin/$(host_triplet)-*; do
             tool="\$(basename "\${tool_path}" | sed -e 's/$(host_triplet)-//')"
             ln -sf "$(host_triplet)-\${tool}" "/usr/local/bin/\${tool}"

--- a/linux/package_linux.jl
+++ b/linux/package_linux.jl
@@ -37,31 +37,57 @@ packages = [
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do rootfs, chroot_ENV
     my_chroot(args...) = root_chroot(rootfs, "bash", "-c", args...; ENV=chroot_ENV)
 
-    # Install GCC 9, specifically
-    @info("Installing gcc-9")
-    gcc_install_cmd = """
-    echo 'deb http://deb.debian.org/debian stable main' >> /etc/apt/sources.list && \\
-    apt-get update && \\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-9 g++-9 gfortran-9
-    """
-    gcc_symlink_cmd = """
-    # Create symlinks for `gcc` -> `gcc-9`, etc...
-    for tool_path in /usr/bin/*-9; do
-        tool="\$(basename "\${tool_path}" | sed -e 's/-9//')"
-        ln -sf "\${tool}-9" "/usr/bin/\${tool}"
-    done
-    """
-    my_chroot(gcc_install_cmd)
-    my_chroot(gcc_symlink_cmd)
+    if arch == "x86_64"
+        host_triplet = "x86_64-linux-gnu"
+        # Install GCC 9 from Elliot's repo
+        repo_release_url = "https://github.com/staticfloat/linux-gcc-toolchains/releases/download/GCC-v9.1.0-x86_64-linux-gnu"
+        gcc_install_cmd = """
+        cd /usr/local
+        curl -L $(repo_release_url)/GCC.v9.1.0.$(host_triplet)-target_libc+glibc-target_os+linux-target_arch+x86_64.tar.gz | tar zx
+        curl -L $(repo_release_url)/Binutils.v2.24.0.$(host_triplet)-target_libc+glibc-target_os+linux-target_arch+x86_64.tar.gz | tar zx
+        curl -L $(repo_release_url)/Zlib.v1.2.12.$(host_triplet).tar.gz | tar zx
+        cd /usr/local/$(host_triplet)/
+        curl -L $(repo_release_url)/Glibc.v2.12.2.$(host_triplet).tar.gz | tar zx
+        curl -L $(repo_release_url)/LinuxKernelHeaders.v5.15.14.x86_64-linux-target_os+linux-target_arch+x86_64.tar.gz | tar zx
+        """
+        gcc_symlink_cmd = """
+        # Create symlinks for `gcc` -> `gcc-9`, etc...
+        for tool_path in /usr/local/bin/$(host_triplet)-*; do
+            tool="\$(basename "\${tool_path}" | sed -e 's/$(host_triplet)-//')"
+            ln -sf "$(host_triplet)-\${tool}" "/usr/local/bin/\${tool}"
+        done
+        """
+        my_chroot(gcc_install_cmd)
+        my_chroot(gcc_symlink_cmd)
+    else
+        # Install GCC 9 from apt
+        @info("Installing gcc-9")
+        gcc_install_cmd = """
+        echo 'deb http://deb.debian.org/debian stable main' >> /etc/apt/sources.list && \\
+        apt-get update && \\
+        DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-9 g++-9 gfortran-9
+        """
+        gcc_symlink_cmd = """
+        # Create symlinks for `gcc` -> `gcc-9`, etc...
+        for tool_path in /usr/bin/*-9; do
+            tool="\$(basename "\${tool_path}" | sed -e 's/-9//')"
+            ln -sf "\${tool}-9" "/usr/bin/\${tool}"
+        done
+        """
+        my_chroot(gcc_install_cmd)
+        my_chroot(gcc_symlink_cmd)
+    end
     my_chroot("which gcc")
     my_chroot("which -a gcc")
     my_chroot("which g++")
     my_chroot("which -a g++")
-    my_chroot("which gfortran")
-    my_chroot("which -a gfortran")
+
+    # We're not going to even install gfortran in some cases.  :)
+    #my_chroot("which gfortran")
+    #my_chroot("which -a gfortran")
+    #my_chroot("gfortran --version")
     my_chroot("gcc --version")
     my_chroot("g++ --version")
-    my_chroot("gfortran --version")
 end
 
 upload_gha(tarball_path)


### PR DESCRIPTION
This is the first step in a lot of work, but let's get this stable and then move on to the rest.

@DilumAluthge @brenhinkeller if this works as I think it should, it should unblock our forward momentum on getting linux `x86_64` moved to buildkite.