### PR TITLE
Add `git` and `make` to our `tester` images

### DIFF
--- a/linux/tester_linux.jl
+++ b/linux/tester_linux.jl
@@ -10,8 +10,10 @@ packages = [
     "bash",
     "curl",
     "gdb",
+    "git",
     "lldb",
     "locales",
+    "make",
     "vim",
 ]
 

--- a/linux/tester_musl.jl
+++ b/linux/tester_musl.jl
@@ -6,13 +6,15 @@ arch         = args.arch
 archive      = args.archive
 image        = args.image
 
-packages = [
-    AlpinePackage("bash"),
-    AlpinePackage("curl"),
-    AlpinePackage("gdb"),
-    AlpinePackage("lldb"),
-    AlpinePackage("vim"),
-]
+packages = AlpinePackage.([
+    "bash",
+    "curl",
+    "gdb",
+    "git",
+    "lldb",
+    "make",
+    "vim",
+])
 
 artifact_hash, tarball_path, = alpine_bootstrap(image; archive, packages)
 upload_gha(tarball_path)


### PR DESCRIPTION
I want to actually use the `tester` images to run our tests.