### PR TITLE
Copy our GCC's `libstdc++` over the system-wide `libstdc++`.

### DIFF
--- a/linux/package_linux.jl
+++ b/linux/package_linux.jl
@@ -60,6 +60,12 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
         """
         my_chroot(gcc_install_cmd)
         my_chroot(gcc_symlink_cmd)
+        libstdcxx_replace_cmd = """
+        # Copy g++'s libstdc++.so over the system-wide one,
+        # so that we can run things built by our g++
+        cp -fv /usr/local/$(host_triplet)/lib*/libstdc++*.so* /lib/$(host_triplet)/
+        """
+        my_chroot(libstdcxx_replace_cmd)
     else
         # Install GCC 9 from apt
         @info("Installing gcc-9")


### PR DESCRIPTION
This ensures that we can always run a program built with `g++` within
the packager.  This occurs because the GCC we're shipping has a
(slightly) newer `libstdc++` than the one that ships with the underlying
OS.