### PR TITLE
We need `procps` on `tester_linux`

### DIFF
--- a/linux/tester_linux.jl
+++ b/linux/tester_linux.jl
@@ -14,6 +14,7 @@ packages = [
     "lldb",
     "locales",
     "make",
+    "procps",
     "vim",
 ]
 


### PR DESCRIPTION
The `Pkg` tests require `kill`