### PR TITLE
Add zlib to the `llvm_passes` image

### DIFF
--- a/linux/llvm_passes.jl
+++ b/linux/llvm_passes.jl
@@ -22,6 +22,8 @@ packages = [
     "python",
     "python3",
     "wget",
+    "zlib1g",
+    "zlib1g-dev",
 ]
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)


### PR DESCRIPTION
In https://github.com/JuliaCI/julia-buildkite/pull/102, when we trying to build `libunwind`, it fails with `cannot find -lz`, so hopefully this will fix it.