### PR TITLE
It's often useful to have `make` as a part of the aws uploader

### DIFF
--- a/linux/aws_uploader.jl
+++ b/linux/aws_uploader.jl
@@ -15,6 +15,7 @@ packages = [
     "gpg",
     "gpg-agent",
     "locales",
+    "make",
     "vim",
 ]
 


### PR DESCRIPTION
Example: https://buildkite.com/julialang/julia-release-1-dot-8/builds/76#018106cc-df73-4176-9b61-1750bfb6a631/474-476

Note that while this isn't a fatal error for us (since the value is not used in the upload job, only the build job), I don't like it.  :P