### PR TITLE
Add `zstd` to `tester_linux`

### DIFF
--- a/linux/tester_linux.jl
+++ b/linux/tester_linux.jl
@@ -16,6 +16,7 @@ packages = [
     "make",
     "procps",
     "vim",
+    "zstd",
 ]
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)

--- a/src/test_img/args.jl
+++ b/src/test_img/args.jl
@@ -51,6 +51,11 @@ function parse_test_args(args::AbstractVector, file::AbstractString)
             required = false
             default = ""
             help = "Tree hash of the rootfs image."
+        "--run-as-root", "-r"
+            arg_type = Bool
+            required = false
+            default = false
+            help = "Run as root within sandbox."
         "command"
             required = false
             default = Any[]
@@ -61,6 +66,7 @@ function parse_test_args(args::AbstractVector, file::AbstractString)
 
     mount_julia       = parsed_args["mount-julia"]::Bool
     override_tmp_dir  = parsed_args["override-tmp-dir"]::Bool
+    run_as_root       = parsed_args["run-as-root"]::Bool
 
     map_build_dir     = _process_required_string_arg(  parsed_args, "map-build-dir")
     tmpfs_size        = _process_required_string_arg(  parsed_args, "tmpfs-size")
@@ -113,6 +119,7 @@ function parse_test_args(args::AbstractVector, file::AbstractString)
         treehash,
         url,
         working_dir,
+        run_as_root,
     )
 
     return result

--- a/test_rootfs.jl
+++ b/test_rootfs.jl
@@ -11,6 +11,7 @@ tmpfs_size      = args.tmpfs_size
 treehash        = args.treehash
 url             = args.url
 working_dir     = args.working_dir
+run_as_root     = args.run_as_root
 
 # If the artifact is not locally existent, download it
 ensure_artifact_exists_locally(; treehash, url)
@@ -34,6 +35,13 @@ environment_variables["PATH"] = join(path_list, ":")
 environment_variables["HOME"] = "/home/juliaci"
 environment_variables["USER"] = "juliaci"
 
+uid = Sandbox.getuid()
+gid = Sandbox.getgid()
+if run_as_root
+    uid = 0
+    gid = 0
+end
+
 config = SandboxConfig(
     read_only_maps,
     read_write_maps,
@@ -43,9 +51,9 @@ config = SandboxConfig(
     stderr,
     multiarch,
     tmpfs_size,
-    pwd        = working_dir,
-    uid        = Sandbox.getuid(),
-    gid        = Sandbox.getgid(),
+    uid,
+    gid,
+    pwd = working_dir,
 )
 
 with_executor() do exe


### PR DESCRIPTION
I want to upload compressed core dump files, `zstd` does a really good job of compressing them and it's fast.