### PR TITLE
Add `zstd` to `musl` as well

### DIFF
--- a/linux/tester_musl.jl
+++ b/linux/tester_musl.jl
@@ -14,6 +14,7 @@ packages = AlpinePackage.([
     "lldb",
     "make",
     "vim",
+    "zstd",
 ])
 
 artifact_hash, tarball_path, = alpine_bootstrap(image; archive, packages)


### PR DESCRIPTION
We want core dumps here too