### PR TITLE
Add debugging utilities to `llvm_passes`

### DIFF
--- a/linux/llvm_passes.jl
+++ b/linux/llvm_passes.jl
@@ -11,8 +11,10 @@ packages = [
     "bzip2",
     "cmake",
     "curl",
+    "file",
     "gfortran",
     "git",
+    "gdb",
     "less",
     "libatomic1",
     "locales",
@@ -24,6 +26,7 @@ packages = [
     "wget",
     "zlib1g",
     "zlib1g-dev",
+    "zstd",
 ]
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)


### PR DESCRIPTION
We use this image for our "from-source" build on CI, so we need these debugging tools as well.