### PR TITLE
Add Korean locale to `tester_linux`

### DIFF
--- a/linux/debian_minimal.jl
+++ b/linux/debian_minimal.jl
@@ -7,8 +7,8 @@ archive      = args.archive
 image        = args.image
 
 packages = String[]
-locale = nothing
+locales = String[]
 
-artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, locale)
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, locales)
 upload_gha(tarball_path)
 test_sandbox(artifact_hash)

--- a/linux/tester_linux.jl
+++ b/linux/tester_linux.jl
@@ -21,6 +21,13 @@ packages = [
     "zstd",
 ]
 
-artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
+# The test suites use a non-english locale as part of their tests;
+# we provide it in the testing image.
+locales = [
+    "en_US.UTF-8 UTF-8",
+    "ko_KR.EUC-KR EUC-KR",
+]
+
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, locales)
 upload_gha(tarball_path)
 test_sandbox(artifact_hash)


### PR DESCRIPTION
We need this for the locale tests in the Julia test suite.
We don't add this to `tester_musl` because locales there are broken.
X-ref: https://musl.openwall.narkive.com/kO1vpTWJ/setlocale-behavior-with-missing-locales