### PR TITLE
Remove `wget` and add `make`

### DIFF
--- a/linux/python_latex_kitchen_sink.jl
+++ b/linux/python_latex_kitchen_sink.jl
@@ -39,7 +39,7 @@ packages = [
     "vim",
     "gdb",
     "lldb",
-    "wget",
+    "make",
 ]
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)


### PR DESCRIPTION
`wget` is not needed since `curl` can be used instead. `make` is required for building cmdstan. 