### PR TITLE
Always use `apt` for installing packages, so that we don't rely on `debootstrap`'s broken resolver; also, upgrade the `pkgserver_logsync` image to Debian Bullseye

### DIFF
--- a/linux/pkgserver_logsync.jl
+++ b/linux/pkgserver_logsync.jl
@@ -18,6 +18,9 @@ packages = String[
     "zstd",
 ]
 
-artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
+release = "bullseye"
+
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, release)
+
 upload_gha(tarball_path)
 test_sandbox(artifact_hash)

--- a/linux/python_latex_kitchen_sink.jl
+++ b/linux/python_latex_kitchen_sink.jl
@@ -24,7 +24,6 @@ packages = [
     "dbus-user-session",
     "python3-sip",
 
-
     # Get a C compiler, for compiling python extensions
     "build-essential",
     # Get latex, so that we can invoke `pdflatex` and friends

--- a/linux/rr.jl
+++ b/linux/rr.jl
@@ -43,9 +43,14 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, relea
         gpp = "g++-multilib"
     end
 
-    my_chroot("apt-get update")
-    my_chroot("DEBIAN_FRONTEND=noninteractive apt-get install -y gdb")
-    my_chroot("DEBIAN_FRONTEND=noninteractive apt-get install -y $(gpp)")
+    apt_update_and_upgrade = () -> begin
+        my_chroot("DEBIAN_FRONTEND=noninteractive apt update")
+        my_chroot("DEBIAN_FRONTEND=noninteractive apt upgrade -y")
+    end
+    apt_update_and_upgrade()
+    my_chroot("DEBIAN_FRONTEND=noninteractive apt install -y gdb")
+    my_chroot("DEBIAN_FRONTEND=noninteractive apt install -y $(gpp)")
+    apt_update_and_upgrade()
 
     my_chroot("cmake --version")
 end


### PR DESCRIPTION
`debootstrap` doesn't use the same resolver as `apt`, which has led to problems in the past with e.g. dependency resolution of virtual packages. Therefore, instead of using `debootstrap` to install packages, let's always call `debootstrap` with exactly zero packages, and then use `apt` to install all the requested packages. That way, we are always using the `apt` resolver.