### PR TITLE
Upgrade all glibc Linux images from Debian Buster to Debian Bullseye

### DIFF
--- a/linux/llvm_passes.jl
+++ b/linux/llvm_passes.jl
@@ -23,7 +23,6 @@ packages = [
     "m4",
     "perl",
     "pkg-config",
-    "python",
     "python3",
     "wget",
     "zlib1g",

--- a/linux/package_linux.jl
+++ b/linux/package_linux.jl
@@ -30,7 +30,6 @@ packages = [
     "patchelf",
     "perl",
     "pkg-config",
-    "python",
     "python3",
     "vim",
     "wget",

--- a/linux/pkgserver_logsync.jl
+++ b/linux/pkgserver_logsync.jl
@@ -18,9 +18,7 @@ packages = String[
     "zstd",
 ]
 
-release = "bullseye"
-
-artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, release)
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
 
 upload_gha(tarball_path)
 test_sandbox(artifact_hash)

--- a/src/build_img/debian.jl
+++ b/src/build_img/debian.jl
@@ -14,7 +14,7 @@ function debootstrap(f::Function, arch::String, name::String;
                      force::Bool = false,
                      locales::Vector{String} = ["en_US.UTF-8 UTF-8"],
                      packages::Vector{String} = String[],
-                     release::String = "buster",
+                     release::String = "bullseye",
                      variant::String = "minbase")
     if Sys.which("debootstrap") === nothing
         error("Must install `debootstrap`!")


### PR DESCRIPTION
Bullseye is the current stable release of Debian, and Buster is the oldstable (previous stable release). So let's upgrade our images from Buster to Bullseye.