### PR TITLE
Add the `latex.x86_64` image for building the PDF docs on Buildkite

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,6 +83,9 @@ jobs:
 
           # The `npm_linux` image is a helper for ecosystem jobs that need to build NPM packages
           - 'npm_linux.x86_64'
+
+          # The `latex` image is used to build the PDF docs
+          - 'latex.x86_64'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/linux/latex.jl
+++ b/linux/latex.jl
@@ -1,0 +1,39 @@
+using RootfsUtils: parse_build_args, upload_gha, test_sandbox
+using RootfsUtils: debootstrap
+using RootfsUtils: root_chroot
+
+args         = parse_build_args(ARGS, @__FILE__)
+arch         = args.arch
+archive      = args.archive
+image        = args.image
+
+packages = [
+    "bash",
+    "locales",
+    "localepurge",
+]
+
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do rootfs, chroot_ENV
+    my_chroot(args...) = root_chroot(rootfs, "bash", "-eu", "-o", "pipefail", "-c", args...; ENV=chroot_ENV)
+
+    additional_packages = String[
+        "curl",
+        "latexmk",
+        "python3-pygments",
+        "texlive-latex-base",
+        "texlive-latex-extra",
+        "texlive-latex-recommended",
+        "texlive-luatex",
+    ]
+    additional_packages_string = join(additional_packages, " ")
+    cmd = """
+    set -Eeu -o pipefail
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $(additional_packages_string)
+    rm -rf /var/lib/apt/lists/*
+    """
+    my_chroot(cmd)
+end
+
+upload_gha(tarball_path)
+test_sandbox(artifact_hash)


### PR DESCRIPTION
Let's see if `--no-install-recommends` helps us keep this under 5GB.