### PR TITLE
Import inkydragon's windows docker build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,11 +36,35 @@ jobs:
           - 'package_win64'
     steps:
       - uses: actions/checkout@v2
-      - run: docker --version
-      - run: docker build -t ${{ matrix.image }} .
+
+      # Set up `IMAGE_NAME`, which is something like `juliapackaging/package_win64`
+      # and also `TAG_NAME`, which is usually something like `v5.23`, but if we're
+      # not on a tag, it defaults to the gitsha of the current build.  That build
+      # won't be pushed, because we only push on tags, but we need to define this
+      # for our actual `docker build` step below.
+      - run: |
+          if ( "${{ github.ref_name }}" -Like "v*" ) {
+            Write-Output "TAG_NAME=${{ github.ref_name }}" >> $env:GITHUB_ENV
+          } else {
+            Write-Output "TAG_NAME=${{ github.sha }}" >> $env:GITHUB_ENV
+          }
+          Write-Output "IMAGE_NAME=juliapackaging/${{ matrix.image }}" >> $env:GITHUB_ENV
+      - run: docker build -t ${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }} .
         working-directory: windows/${{ matrix.image }}
-      - run: docker images ${{ matrix.image }} --no-trunc
-      - run: docker images ${{ matrix.image }} --digests
-      - run: docker inspect ${{ matrix.image }}
-      - run: docker run -d ${{ matrix.image }}
-      - run: docker ps
+      - run: docker tag ${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }} ${{ env.IMAGE_NAME }}:latest
+
+      # Dump some debugging output to ensure everything works properly
+      - run: docker images ${{ env.IMAGE_NAME }} --digests
+      - run: docker run ${{ env.IMAGE_NAME }} bash -c "gcc -dumpmachine; gcc --version"
+
+      # Login to docker hub so we can push it up, but only do so on a tag
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ github.event_name == 'release' }}
+      - run: |
+          docker push ${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}
+          docker push ${{ env.IMAGE_NAME }}:latest
+        if: ${{ github.event_name == 'release' }}

--- a/windows/package_win32/Dockerfile
+++ b/windows/package_win32/Dockerfile
@@ -1,3 +1,44 @@
-FROM mcr.microsoft.com/windows/servercore/iis
+# SPDX-License-Identifier: MIT
 
-WORKDIR /build
+# See "Full Tag Listing" in https://hub.docker.com/_/microsoft-windows-servercore
+ARG WIN_VERSION=ltsc2022
+FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION AS MSYS2_download
+
+ARG MSYS2_VERSION=20220904
+ARG MSYS2_DOWNLOAD_URL=https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-${MSYS2_VERSION}.sfx.exe
+RUN setx /M  PATH C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%  && \
+    powershell -Command "Invoke-WebRequest -Uri %MSYS2_DOWNLOAD_URL% -OutFile C:/windows/temp/msys2-base.sfx.exe"  && \
+    C:\windows\temp\msys2-base.sfx.exe x -o"C:"
+# NOTE: workaround for "gpg: error reading key: Connection timed out"
+RUN bash -l -c "exit 0"
+RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
+    bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
+    bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
+    bash -l -c " \
+        pacman -S --needed --noconfirm --noprogressbar \
+            cmake diffutils git m4 make patch tar p7zip curl python3 \
+            mingw-w64-i686-gcc \
+        "  && \
+    bash -l -c "pacman -Scc --noconfirm"  && \
+    echo ---- [%date% %time%] Pkg install done!
+# NOTE: If you hang here >10 min. You may want to `zap` temp files.
+#   ref: https://github.com/msys2/MSYS2-packages/issues/2305#issuecomment-758162640
+
+
+# ---- Move to new container, to drop messy build history
+ARG WIN_VERSION=ltsc2022
+FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION
+
+COPY --from=MSYS2_download C:/msys64 C:/msys64
+
+# Set default environment variables and setup useful symlinks
+RUN setx /M  PATH C:\msys64\mingw32\bin;C:\msys64\usr\bin;%PATH%  && \
+    mklink /J  C:\msys64\home\ContainerUser C:\Users\ContainerUser  && \
+    setx /M  HOME C:\msys64\home\ContainerUser
+WORKDIR C:/msys64/home/ContainerUser
+
+# Select the mingw64 environment: https://www.msys2.org/docs/environments/
+ENV MSYSTEM=MINGW64
+
+# Default to `bash` for interactive builds
+CMD ["bash"]

--- a/windows/package_win64/Dockerfile
+++ b/windows/package_win64/Dockerfile
@@ -1,3 +1,39 @@
-FROM mcr.microsoft.com/windows/servercore/iis
+# SPDX-License-Identifier: MIT
 
-WORKDIR /build
+# See "Full Tag Listing" in https://hub.docker.com/_/microsoft-windows-servercore
+ARG WIN_VERSION=ltsc2022
+FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION AS MSYS2_download
+
+ARG MSYS2_VERSION=20220904
+ARG MSYS2_DOWNLOAD_URL=https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-${MSYS2_VERSION}.sfx.exe
+RUN setx /M  PATH C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%  && \
+    powershell -Command "Invoke-WebRequest -Uri %MSYS2_DOWNLOAD_URL% -OutFile C:/windows/temp/msys2-base.sfx.exe"  && \
+    C:\windows\temp\msys2-base.sfx.exe x -o"C:"
+# NOTE: workaround for "gpg: error reading key: Connection timed out"
+RUN bash -l -c "exit 0"
+RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
+    bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
+    bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
+    bash -l -c " \
+        pacman -S --needed --noconfirm --noprogressbar \
+            cmake diffutils git m4 make patch tar p7zip curl python3 \
+            mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-fortran \
+        "  && \
+    bash -l -c "pacman -Scc --noconfirm"  && \
+    echo ---- [%date% %time%] Pkg install done!
+# NOTE: If you hang here >10 min. You may want to `zap` temp files.
+#   ref: https://github.com/msys2/MSYS2-packages/issues/2305#issuecomment-758162640
+
+
+# ---- Move to new container
+ARG WIN_VERSION=ltsc2022
+FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION
+
+COPY --from=MSYS2_download C:/msys64 C:/msys64
+RUN setx /M  PATH C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%  && \
+    mklink /J  C:\msys64\home\ContainerUser C:\Users\ContainerUser  && \
+    setx /M  HOME C:\msys64\home\ContainerUser
+
+WORKDIR C:/msys64/home/ContainerUser
+ENV MSYSTEM=MINGW64
+CMD ["bash", "-l"]

--- a/windows/package_win64/Dockerfile
+++ b/windows/package_win64/Dockerfile
@@ -17,7 +17,7 @@ RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
     bash -l -c " \
         pacman -S --needed --noconfirm --noprogressbar \
             cmake diffutils git m4 make patch tar p7zip curl python3 \
-            mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-fortran \
+            mingw-w64-x86_64-gcc \
         "  && \
     bash -l -c "pacman -Scc --noconfirm"  && \
     echo ---- [%date% %time%] Pkg install done!
@@ -25,15 +25,20 @@ RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
 #   ref: https://github.com/msys2/MSYS2-packages/issues/2305#issuecomment-758162640
 
 
-# ---- Move to new container
+# ---- Move to new container, to drop messy build history
 ARG WIN_VERSION=ltsc2022
 FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION
 
 COPY --from=MSYS2_download C:/msys64 C:/msys64
+
+# Set default environment variables and setup useful symlinks
 RUN setx /M  PATH C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%  && \
     mklink /J  C:\msys64\home\ContainerUser C:\Users\ContainerUser  && \
     setx /M  HOME C:\msys64\home\ContainerUser
-
 WORKDIR C:/msys64/home/ContainerUser
+
+# Select the mingw64 environment: https://www.msys2.org/docs/environments/
 ENV MSYSTEM=MINGW64
-CMD ["bash", "-l"]
+
+# Default to `bash` for interactive builds
+CMD ["bash"]


### PR DESCRIPTION
Chengyu has kindly forged a path forward for us to use windows docker containers on CI, let's import his win64 packaging docker container here.

This code gratefully copied from: https://github.com/inkydragon/msys2-mingw-w64

I have dropped the "Unlicense" SPDX modifier and kept only MIT, to match the rest of this repository.