### PR TITLE
Install custom `SJLJ` toolchain on win32

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
       - run: true
   build_windows:
     timeout-minutes: 60
-    name: build_windows / ${{ matrix.image }}_win${{ matrix.bits }}
+    name: build_windows / ${{ matrix.image }}-windows-${{ matrix.arch }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -34,10 +34,8 @@ jobs:
         include:
           - image: 'package'
             arch: 'x86_64'
-            bits: '64'
           - image: 'package'
             arch: 'i686'
-            bits: '32'
     steps:
       - uses: actions/checkout@v2
 
@@ -53,8 +51,8 @@ jobs:
             Write-Output "TAG_NAME=${{ github.sha }}" >> $env:GITHUB_ENV
           }
           Write-Output "IMAGE_NAME=juliapackaging/${{ matrix.image }}-windows-${{ matrix.arch }}" >> $env:GITHUB_ENV
-      - run: docker build -t ${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }} --build-arg BITS=${{ matrix.bits }} --build-arg ARCH=${{ matrix.arch }} .
-        working-directory: windows/${{ matrix.image }}
+      - run: docker build -t ${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }} .
+        working-directory: windows/${{ matrix.image }}-${{ matrix.arch }}
       - run: docker tag ${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }} ${{ env.IMAGE_NAME }}:latest
 
       # Dump some debugging output to ensure everything works properly

--- a/windows/package-i686/Dockerfile
+++ b/windows/package-i686/Dockerfile
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+
+# See "Full Tag Listing" in https://hub.docker.com/_/microsoft-windows-servercore
+ARG WIN_VERSION=ltsc2022
+FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION AS MSYS2_download
+
+# We always download x86_64 MSYS2 installer, since our system itself is x86_64.
+ARG MSYS2_VERSION=20220904
+ARG MSYS2_DOWNLOAD_URL=https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-${MSYS2_VERSION}.sfx.exe
+RUN setx /M PATH "C:\msys64\mingw32\bin;C:\msys64\usr\bin;%PATH%" && \
+    powershell -Command "Invoke-WebRequest -Uri %MSYS2_DOWNLOAD_URL% -OutFile C:\windows\temp\msys2-base.sfx.exe"  && \
+    C:\windows\temp\msys2-base.sfx.exe x -o"C:"
+# NOTE: workaround for "gpg: error reading key: Connection timed out"
+RUN bash -l -c "exit 0"
+RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
+    bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
+    bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
+    bash -l -c " \
+        pacman -S --needed --noconfirm --noprogressbar \
+            cmake diffutils git m4 make patch tar p7zip curl python3 \
+        "  && \
+    bash -l -c "pacman -Scc --noconfirm"  && \
+    echo ---- [%date% %time%] Pkg install done!
+# NOTE: If you hang here >10 min. You may want to `zap` temp files.
+#   ref: https://github.com/msys2/MSYS2-packages/issues/2305#issuecomment-758162640
+
+# Because we need an SJLJ toolchain on win32, we manually download one and unpack it into `C:\msys64`:
+ARG GCC_DOWNLOAD_URL=https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev0/i686-12.2.0-release-posix-sjlj-rt_v10-rev0.7z
+RUN powershell -Command "Invoke-WebRequest -Uri %GCC_DOWNLOAD_URL% -OutFile C:\windows\temp\gcc.7z" && \
+    cd "C:\msys64" && \
+    C:\msys64\usr\lib\p7zip\7z.exe x "/c/windows/temp/gcc.7z"
+
+# ---- Move to new container, to drop messy build history
+ARG WIN_VERSION=ltsc2022
+FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION
+
+COPY --from=MSYS2_download C:/msys64 C:/msys64
+
+# Set default environment variables and setup useful symlinks
+# Note that we add an entry for `buildkite-agent` here despite it not being within
+# the image, because we expect it to be mounted within us in the future.
+RUN setx /M PATH "C:\buildkite-agent\bin;C:\msys64\mingw32\bin;C:\msys64\usr\bin;%PATH%" && \
+    mklink /J  C:\msys64\home\ContainerUser C:\Users\ContainerUser  && \
+    setx /M  HOME C:\msys64\home\ContainerUser
+WORKDIR C:/msys64/home/ContainerUser
+
+# Select the mingw64 environment: https://www.msys2.org/docs/environments/
+ENV MSYSTEM=MINGW64
+
+# Default to `bash` for interactive builds
+CMD ["bash"]

--- a/windows/package-x86_64/Dockerfile
+++ b/windows/package-x86_64/Dockerfile
@@ -3,13 +3,11 @@
 # See "Full Tag Listing" in https://hub.docker.com/_/microsoft-windows-servercore
 ARG WIN_VERSION=ltsc2022
 FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION AS MSYS2_download
-ARG ARCH=x86_64
-ARG BITS=64
 
 # We always download x86_64 MSYS2 installer, since our system itself is x86_64.
 ARG MSYS2_VERSION=20220904
 ARG MSYS2_DOWNLOAD_URL=https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-${MSYS2_VERSION}.sfx.exe
-RUN setx /M PATH "C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%" && \
+RUN setx /M PATH "C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%" && \
     powershell -Command "Invoke-WebRequest -Uri %MSYS2_DOWNLOAD_URL% -OutFile C:/windows/temp/msys2-base.sfx.exe"  && \
     C:\windows\temp\msys2-base.sfx.exe x -o"C:"
 # NOTE: workaround for "gpg: error reading key: Connection timed out"
@@ -20,7 +18,7 @@ RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
     bash -l -c " \
         pacman -S --needed --noconfirm --noprogressbar \
             cmake diffutils git m4 make patch tar p7zip curl python3 \
-            mingw-w64-${ARCH}-gcc \
+            mingw-w64-x86_64-gcc \
         "  && \
     bash -l -c "pacman -Scc --noconfirm"  && \
     echo ---- [%date% %time%] Pkg install done!
@@ -31,14 +29,13 @@ RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
 # ---- Move to new container, to drop messy build history
 ARG WIN_VERSION=ltsc2022
 FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION
-ARG BITS=64
 
 COPY --from=MSYS2_download C:/msys64 C:/msys64
 
 # Set default environment variables and setup useful symlinks
 # Note that we add an entry for `buildkite-agent` here despite it not being within
 # the image, because we expect it to be mounted within us in the future.
-RUN setx /M PATH "C:\buildkite-agent\bin;C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%" && \
+RUN setx /M PATH "C:\buildkite-agent\bin;C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%" && \
     mklink /J  C:\msys64\home\ContainerUser C:\Users\ContainerUser  && \
     setx /M  HOME C:\msys64\home\ContainerUser
 WORKDIR C:/msys64/home/ContainerUser


### PR DESCRIPTION
We need to use the SJLJ exception handling technique when targeting win32, but because msys2 defaults to dw2, we can't use pacman to install their compiler.  Instead, we use a prebuilt binary from elsewhere on the internet.