### PR TITLE
Add `net-tools` to `tester_linux`

### DIFF
--- a/linux/tester_linux.jl
+++ b/linux/tester_linux.jl
@@ -16,6 +16,7 @@ packages = [
     "locales",
     "localepurge",
     "make",
+    "net-tools",
     "openssl",
     "procps",
     "vim",


### PR DESCRIPTION
Jameson wants to be able to run `netstat` and such, which seems like a good idea.