### PR TITLE
Add `zstd` to `agent_linux` images

### DIFF
--- a/linux/agent_linux.jl
+++ b/linux/agent_linux.jl
@@ -21,6 +21,7 @@ packages = [
     "python3",
     "vim",
     "wget",
+    "zstd",
 ]
 
 artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do rootfs, chroot_ENV


### PR DESCRIPTION
While the outer agent images are intentionally quite bare, the compression/decompression speed of `zstd` makes it extremely attractive to use by default within plugins.  I intend to use it in `coppermind` by default, so I'm adding it to the bare agent image for now, with a future "JLL installation plugin" to come.