### PR TITLE
Print out `ld` as well

### DIFF
--- a/linux/package_linux.jl
+++ b/linux/package_linux.jl
@@ -90,9 +90,12 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
     my_chroot("which -a gcc")
     my_chroot("which g++")
     my_chroot("which -a g++")
+    my_chroot("which ld")
+    my_chroot("which -a ld")
 
     my_chroot("gcc --version")
     my_chroot("g++ --version")
+    my_chroot("ld --version")
 end
 
 upload_gha(tarball_path)


### PR DESCRIPTION
This helps us to ensure that we've got the right version of binutils as well