### PR TITLE
Bump x86_64 and i686 minimum glibc version to v2.17 (and thus drop support for RHEL 6 and CentOS 6, but keep support for RHEL 7 and CentOS 7)

### DIFF
--- a/linux/package_linux.jl
+++ b/linux/package_linux.jl
@@ -48,8 +48,8 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
         cross_tags = "target_libc+glibc-target_os+linux-target_call_abi+eabihf-target_arch+$(arch)"
     end
     glibc_version_dict = Dict(
-        "x86_64" => v"2.12.2",
-        "i686" => v"2.12.2",
+        "x86_64" => v"2.17",
+        "i686" => v"2.17",
         "aarch64" => v"2.19",
         "armv7l" => v"2.19",
         "powerpc64le" => v"2.19",


### PR DESCRIPTION
We've been talking about this for ages, our new libuv builds require this, so let's actually do it.  BB can catch up later.

---

Drops support for: RHEL 6, CentOS 6

Keeps support for: RHEL 7, CentOS 7