### PR TITLE
Add `lldb` to the rootfs image used in rr's CI

### DIFF
--- a/linux/rr.jl
+++ b/linux/rr.jl
@@ -18,6 +18,7 @@ packages = [
     "curl",
     "git",
     "libcapnp-dev",
+    "lldb",
     "locales",
     "localepurge",
     "make",


### PR DESCRIPTION
Ref https://github.com/rr-debugger/rr/pull/3689