### PR TITLE
also provide URL with the tree hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ julia --project test_rootfs.jl --url https://github.com/JuliaCI/rootfs-images/re
 This will print out a message with the tree hash of the rootfs. Now, run the following command:
 
 ```
-julia --project test_rootfs.jl --treehash 1234567890000000000000000000000000000000
+julia --project test_rootfs.jl --url https://github.com/JuliaCI/rootfs-images/releases/download/v3.18/package_linux.x86_64.tar.gz --treehash 1234567890000000000000000000000000000000
 ```
 
 (Replace `1234567890000000000000000000000000000000` with the tree hash that was printed in the previous step.)


### PR DESCRIPTION
As described does not work:

```
kristofferc@deepsea3:~/rootfs-images$ julia --project test_rootfs.jl --url https://github.com/JuliaCI/rootfs-images/releases/download/v3.18/package_linux.x86_64.tar.gz

┌ Warning: Hash not provided; this will download the tarball, then fail, so you can see the true hash
└ @ RootfsUtils ~/rootfs-images/src/utils/args.jl:16
[ Info: Artifact did not exist locally, downloading
[ Info: Unpacking /tmp/jl_GL0NUR2BUD-download.gz into /home/kristofferc/.julia/artifacts/jl_vf9Tmh...
ERROR: LoadError: Tree Hash Mismatch!
  Expected git-tree-sha1:   0000000000000000000000000000000000000000
  Calculated git-tree-sha1: 23cfae2cfdeeb8e25484388241d2d723144618a1

Stacktrace:
 [1] ensure_artifact_exists_locally(; treehash::Base.SHA1, url::String)
   @ RootfsUtils ~/rootfs-images/src/test_img/test.jl:36
 [2] top-level scope
   @ ~/rootfs-images/test_rootfs.jl:17
in expression starting at /home/kristofferc/rootfs-images/test_rootfs.jl:17

kristofferc@deepsea3:~/rootfs-images$ julia --project test_rootfs.jl --treehash 23cfae2cfdeeb8e25484388241d2d723144618a1
ERROR: LoadError: ArgumentError: The artifact does not exist locally, so you must provide the URL.

kristofferc@deepsea3:~/rootfs-images$ julia --project test_rootfs.jl --url https://github.com/JuliaCI/rootfs-images/releases/download/v3.18/package_linux.x86_64.tar.gz --treehash 23cfae2cfdeeb8e25484388241d2d723144618a1
[ Info: Artifact did not exist locally, downloading
[ Info: Unpacking /tmp/jl_RWNa9wfITK-download.gz into /home/kristofferc/.julia/artifacts/jl_TUlq1u...
  Downloaded artifact: alpine-rootfs
I have no name!@deepsea3:/build$ 
```