### PR TITLE
Bump msys2 version to the latest release as an attempt to fix the weird ASLR issue

### DIFF
--- a/windows/package-i686/Dockerfile
+++ b/windows/package-i686/Dockerfile
@@ -5,7 +5,7 @@ ARG WIN_VERSION=ltsc2022
 FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION AS MSYS2_download
 
 # We always download x86_64 MSYS2 installer, since our system itself is x86_64.
-ARG MSYS2_VERSION=20220904
+ARG MSYS2_VERSION=20240507
 ARG MSYS2_DOWNLOAD_URL=https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-${MSYS2_VERSION}.sfx.exe
 RUN setx /M PATH "C:\msys64\mingw32\bin;C:\msys64\usr\bin;%PATH%" && \
     powershell -Command "Invoke-WebRequest -Uri %MSYS2_DOWNLOAD_URL% -OutFile C:\windows\temp\msys2-base.sfx.exe"  && \

--- a/windows/package-x86_64/Dockerfile
+++ b/windows/package-x86_64/Dockerfile
@@ -5,7 +5,7 @@ ARG WIN_VERSION=ltsc2022
 FROM mcr.microsoft.com/windows/servercore:$WIN_VERSION AS MSYS2_download
 
 # We always download x86_64 MSYS2 installer, since our system itself is x86_64.
-ARG MSYS2_VERSION=20220904
+ARG MSYS2_VERSION=20240507
 ARG MSYS2_DOWNLOAD_URL=https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-${MSYS2_VERSION}.sfx.exe
 RUN setx /M PATH "C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%" && \
     powershell -Command "Invoke-WebRequest -Uri %MSYS2_DOWNLOAD_URL% -OutFile C:/windows/temp/msys2-base.sfx.exe"  && \


### PR DESCRIPTION
This bumps the msys2 versions to see if this can fix the weird ASLR issue we've seen in windows builders. This does mean we will get very new compilers for windows, this is hopefully not an issue (glibc compatibility isn't a thing and we ship a very new libstdc++) 

It's GCC 13.2 for reference so it should be the same version libstdc++ that we have in julia since at least 1.10