### PR TITLE
Add `time` to the `llvm_passes` image

### DIFF
--- a/linux/llvm_passes.jl
+++ b/linux/llvm_passes.jl
@@ -24,6 +24,7 @@ packages = [
     "perl",
     "pkg-config",
     "python3",
+    "time",
     "wget",
     "zlib1g",
     "zlib1g-dev",


### PR DESCRIPTION
This fixes `make build-stats` failing when using the `llvm-passes` image, as the scheduled build does. https://github.com/JuliaCI/rootfs-images/pull/240 did the same thing for the `package-*` images