### PR TITLE
Remove zlib from llvm_passes image

### DIFF
--- a/linux/llvm_passes.jl
+++ b/linux/llvm_passes.jl
@@ -26,8 +26,6 @@ packages = [
     "python3",
     "time",
     "wget",
-    "zlib1g",
-    "zlib1g-dev",
     "zstd",
 ]
 


### PR DESCRIPTION
Should no longer be necessary after https://github.com/JuliaLang/julia/pull/57798 and https://github.com/JuliaLang/julia/pull/57792