### PR TITLE
Windows: Install correct CMake

### DIFF
--- a/windows/package-i686/Dockerfile.2022
+++ b/windows/package-i686/Dockerfile.2022
@@ -17,7 +17,7 @@ RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
     bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
     bash -l -c " \
         pacman -S --needed --noconfirm --noprogressbar \
-            cmake diffutils git m4 make patch tar p7zip mingw-w64-i686-7zip curl python3 \
+            mingw-w64-i686-cmake diffutils git m4 make patch tar p7zip mingw-w64-i686-7zip curl python3 \
         "  && \
     bash -l -c "git config --system core.longpaths true" && \
     bash -l -c "pacman -Scc --noconfirm"  && \

--- a/windows/package-x86_64/Dockerfile.2022
+++ b/windows/package-x86_64/Dockerfile.2022
@@ -17,7 +17,7 @@ RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
     bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
     bash -l -c " \
         pacman -S --needed --noconfirm --noprogressbar \
-            cmake diffutils git m4 make patch tar p7zip curl python3 openssl gnupg2 \
+            mingw-w64-x86_64-cmake diffutils git m4 make patch tar p7zip curl python3 openssl gnupg2 \
             mingw-w64-x86_64-gcc \
         "  && \
     bash -l -c "git config --system core.longpaths true" && \


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/59001

Quoting from https://github.com/JuliaLang/julia/pull/59001#issue-3230286063:

> msys2 ships 2 different cmake packages, one built natively (with mingw prefix in the package name) and one built against the posix emulation environment. The posix emulation one does not work because it will detect unix-style paths, which it then writes into files that native tools process. Unlike during command invocation (where the msys2 runtime library does path translation), when paths are written to files, they are written verbatim.