### PR TITLE
Update awscli version by updating debian release

### DIFF
--- a/linux/aws_uploader.jl
+++ b/linux/aws_uploader.jl
@@ -21,6 +21,6 @@ packages = [
     "vim",
 ]
 
-artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
+artifact_hash, tarball_path, = debootstrap(arch, image; release = "trixie", archive, packages)
 upload_gha(tarball_path)
 test_sandbox(artifact_hash)


### PR DESCRIPTION
Updating the debian version seemed like the simplest approach (bullseye is EOL anyway). Needed for https://github.com/JuliaCI/julia-buildkite/pull/474.