### PR TITLE
Install the AWS CLI in the package_linux, llvm_passes and tester_linu…

### DIFF
--- a/linux/llvm_passes.jl
+++ b/linux/llvm_passes.jl
@@ -1,5 +1,6 @@
 using RootfsUtils: parse_build_args, upload_gha, test_sandbox
 using RootfsUtils: debootstrap
+using RootfsUtils: install_awscli
 
 args         = parse_build_args(ARGS, @__FILE__)
 arch         = args.arch
@@ -29,6 +30,10 @@ packages = [
     "zstd",
 ]
 
-artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages)
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do rootfs, chroot_ENV
+    # The build jobs upload their products to S3 from within the sandbox,
+    # using OIDC-issued credentials; they need a recent AWS CLI to do so.
+    install_awscli(rootfs, chroot_ENV, arch)
+end
 upload_gha(tarball_path)
 test_sandbox(artifact_hash)

--- a/linux/package_linux.jl
+++ b/linux/package_linux.jl
@@ -1,5 +1,6 @@
 using RootfsUtils: parse_build_args, upload_gha, test_sandbox
 using RootfsUtils: debootstrap
+using RootfsUtils: install_awscli
 using RootfsUtils: root_chroot
 
 args         = parse_build_args(ARGS, @__FILE__)
@@ -92,6 +93,10 @@ artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages) do ro
     my_chroot("gcc --version")
     my_chroot("g++ --version")
     my_chroot("ld --version")
+
+    # The build jobs upload their products to S3 from within the sandbox,
+    # using OIDC-issued credentials; they need a recent AWS CLI to do so.
+    install_awscli(rootfs, chroot_ENV, arch)
 end
 
 upload_gha(tarball_path)

--- a/linux/tester_linux.jl
+++ b/linux/tester_linux.jl
@@ -1,5 +1,6 @@
 using RootfsUtils: parse_build_args, upload_gha, test_sandbox
 using RootfsUtils: debootstrap
+using RootfsUtils: install_awscli
 
 args         = parse_build_args(ARGS, @__FILE__)
 arch         = args.arch
@@ -30,6 +31,11 @@ locales = [
     "ko_KR.EUC-KR EUC-KR",
 ]
 
-artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, locales)
+artifact_hash, tarball_path, = debootstrap(arch, image; archive, packages, locales) do rootfs, chroot_ENV
+    # The test jobs fetch secrets (e.g. the Buildkite Test Analytics token
+    # via `aws ssm get-parameter`) from within the sandbox, using
+    # OIDC-issued credentials; they need the AWS CLI to do so.
+    install_awscli(rootfs, chroot_ENV, arch)
+end
 upload_gha(tarball_path)
 test_sandbox(artifact_hash)

--- a/src/RootfsUtils.jl
+++ b/src/RootfsUtils.jl
@@ -15,6 +15,7 @@ include("types.jl")
 
 include("build_img/alpine.jl")
 include("build_img/args.jl")
+include("build_img/awscli.jl")
 include("build_img/common.jl")
 include("build_img/debian.jl")
 

--- a/src/build_img/awscli.jl
+++ b/src/build_img/awscli.jl
@@ -1,0 +1,38 @@
+# Install the AWS CLI into a Debian-based rootfs.
+#
+# Julia's Buildkite pipelines obtain short-lived AWS credentials via
+# Buildkite OIDC and upload build products to S3 directly from within the
+# rootfs sandbox, using S3 conditional writes for write-once semantics
+# (`aws s3api put-object --if-none-match '*'`). Conditional writes require
+# a recent CLI: AWS CLI v2 >= 2.19, or AWS CLI v1 >= 1.36.
+#
+# AWS only publishes official AWS CLI v2 binaries for x86_64 and aarch64
+# Linux, so on all other architectures we fall back to a pip-installed
+# AWS CLI v1, which is pure Python and therefore works everywhere.
+function install_awscli(rootfs::String, chroot_ENV::AbstractDict, arch::String)
+    arch = normalize_arch(arch)
+    env = copy(chroot_ENV)
+    env["DEBIAN_FRONTEND"] = "noninteractive"
+    my_chroot(args...) = root_chroot(rootfs, "bash", "-eu", "-o", "pipefail", "-c", args...; ENV=env)
+    if arch in ("x86_64", "aarch64")
+        # Install the official AWS CLI v2 binary distribution.
+        my_chroot("""
+        apt-get install -y unzip
+        curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o /tmp/awscliv2.zip
+        unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
+        /tmp/awscliv2/aws/install
+        rm -rf /tmp/awscliv2 /tmp/awscliv2.zip
+        """)
+    else
+        # No official AWS CLI v2 binaries exist for this architecture
+        # (and Debian's `awscli` package is too old on bookworm), so
+        # install the pure-Python AWS CLI v1 from PyPI instead.
+        my_chroot("""
+        apt-get install -y python3-pip
+        pip3 install --break-system-packages "awscli>=1.36"
+        """)
+    end
+
+    # Print the installed version, and fail the image build if `aws` is broken.
+    my_chroot("aws --version")
+end


### PR DESCRIPTION
…x images

julia-buildkite is moving to OIDC-issued AWS credentials with write-once S3 uploads (JuliaCI/julia-buildkite#544). The build jobs now stage their products to S3 directly from within the rootfs sandbox via `aws s3api put-object --if-none-match '*'` (an S3 conditional write), and the test jobs optionally fetch the Buildkite Test Analytics token via `aws ssm get-parameter`. The bare Buildkite agents do not provide an AWS CLI, so the images must.

S3 conditional writes require a recent CLI: AWS CLI v2 >= 2.19, or AWS CLI v1 >= 1.36 (botocore >= 1.35.54). Debian bookworm's `awscli` (2.9.19, and 2.17.3 in backports) is too old, so instead:

  * on x86_64 and aarch64, install the official AWS CLI v2 binary distribution from awscli.amazonaws.com;
  * on i686, armv7l and powerpc64le (for which AWS publishes no official binaries), pip-install the pure-Python AWS CLI v1, pinned >= 1.36.

The install logic lives in a shared `RootfsUtils.install_awscli` helper and runs `aws --version` at the end, so a broken install fails the image build. The alpine-based package_musl/tester_musl images are left alone for now: they are currently disabled in julia-buildkite, and their Alpine 3.13 base is too old for any reasonable AWS CLI install (no glibc for the v2 binaries, Python 3.8 + apk awscli 1.18), so re-enabling them will need an Alpine base bump first.