### PR TITLE
package-i686: extract the GCC toolchain with bsdtar (mingw32 7zip is …

### DIFF
--- a/windows/package-i686/Dockerfile.2022
+++ b/windows/package-i686/Dockerfile.2022
@@ -17,7 +17,7 @@ RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
     bash -l -c "pacman -Syu --needed --noconfirm --noprogressbar"  && \
     bash -l -c " \
         pacman -S --needed --noconfirm --noprogressbar \
-            mingw-w64-i686-cmake diffutils git m4 make patch tar p7zip mingw-w64-i686-7zip curl python3 \
+            mingw-w64-i686-cmake diffutils git libarchive m4 make patch tar p7zip curl python3 \
         "  && \
     bash -l -c "git config --system core.longpaths true" && \
     bash -l -c "pacman -Scc --noconfirm"  && \
@@ -29,7 +29,7 @@ RUN bash -l -c "pacman -Syuu --noconfirm --noprogressbar"  && \
 ARG GCC_DOWNLOAD_URL=https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev0/i686-12.2.0-release-posix-sjlj-rt_v10-rev0.7z
 RUN powershell -Command "Invoke-WebRequest -Uri %GCC_DOWNLOAD_URL% -OutFile C:\windows\temp\gcc.7z" && \
     cd "C:\msys64" && \
-    bash -l -c "/c/msys64/mingw32/bin/7z -y x -- /c/windows/temp/gcc.7z" && \
+    bash -l -c "bsdtar -xf /c/windows/temp/gcc.7z" && \
     bash -l -c "cp /mingw32/bin/gcc.exe /mingw32/bin/cc.exe"
 
 # ---- Move to new container, to drop messy build history


### PR DESCRIPTION
…gone)

MSYS2 removed mingw-w64-i686-7zip from the mingw32 repo on 2026-06-03 (msys2/MINGW-packages@b13c6d3a, part of the ongoing 32-bit phase-out; the package had already been dropped and restored once before, in msys2/MINGW-packages@17ab3aeb). Since Dockerfile.2022 does a fresh pacman -Syuu before installing, every image build now fails with 'error: target not found: mingw-w64-i686-7zip'.

Replace the extraction of the niXman GCC .7z with bsdtar from the msys 'libarchive' package (now listed explicitly), which is unaffected by the mingw32 phase-out, reads 7z archives, and overwrites existing files by default -- the behavior mingw-w64-i686-7zip was introduced for in #276.

Note: mingw-w64-i686-cmake on the same line survives this MSYS2 batch but is likely to be removed eventually too; the i686 image will need to migrate off the mingw32 pacman repo as the phase-out completes.