### PR TITLE
Windows: Stop building Dockerfiles for 32-bit Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,6 @@ jobs:
           - package
         arch:
           - x86_64
-          - i686
         windows-version:
           - '2022'
           # - '2025'


### PR DESCRIPTION
For more context, see: https://discourse.julialang.org/t/phasing-out-julia-support-for-32-bit-windows/137912

TODO:
- [ ] Wait until Julia 1.14.0 is released (at which point we'll stop making 1.13.x releases)