### PR TITLE
julia_publish: add pigz for parallel tarball compression

### DIFF
--- a/linux/julia_publish.jl
+++ b/linux/julia_publish.jl
@@ -74,6 +74,7 @@ packages = [
     "make",
     "openssh-client",
     "p7zip-full",            # provides `7z` for the Windows `.zip`
+    "pigz",                  # parallel gzip for the release tarball repacks
     "python3",
     "tar",
     "unzip",


### PR DESCRIPTION
The `julia-publish` pipeline's `upload_julia.sh` repacks the ~2 GB release tarballs (macOS signed tree, Windows codesigned tree) and wants to use `pigz` for parallel gzip compression when available, falling back to single-threaded `gzip` otherwise. Ship `pigz` in the `julia_publish` image so the parallel path is taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)